### PR TITLE
Update D405 gripper ROI + tag params for new AprilTag placement

### DIFF
--- a/configs/sroi_v2_d405.json
+++ b/configs/sroi_v2_d405.json
@@ -1,9 +1,10 @@
 {
     "description": "SROI v2 with Intel RealSense D405 camera",
-    "gripper_roi": 200,
+    "gripper_roi": 395,
+    "gripper_roi_bottom": 450,
     "tag_family": "tag16h5",
     "left_gripper_tag_id": 0,
     "right_gripper_tag_id": 15,
-    "nominal_diag_distance": 42,
-    "threshold": 15
+    "nominal_diag_distance": 41,
+    "threshold": 9
 }


### PR DESCRIPTION
The AprilTags were physically moved to a new (lower) position in the camera frame. This updates the D405 config to match, based on measurements from a test recording.

Changes to `configs/sroi_v2_d405.json`:
- `gripper_roi`: 200 → **395** (tags now sit at rows ~407–438 of 480)
- added `gripper_roi_bottom`: **450** (was unbounded; tightens the band to reduce false positives below the tags)
- `nominal_diag_distance`: 42 → **41** (measured tag diagonal ~41px)
- `threshold`: 15 → **9** (real tags deviate only ≤5px; 15 was ~3x looser than needed. Window now [32,50], still passes all real tags, rejects more size-mismatched false positives)

Validation: full pipeline on a 7-episode test recording — AprilTag co-detection **95%** (gaps avg 2.4 frames), **0 NaN**, all episodes QC `ok`.