### PR TITLE
Add maskgripper mask scheme + comparison tooling (mg >= mh)

### DIFF
--- a/schemes_compare/README.md
+++ b/schemes_compare/README.md
@@ -21,8 +21,11 @@
 
 跑 ORB-SLAM 前，对每个 episode 的 left_/right_ 涂黑夹爪梯形：
 ```bash
-python3 schemes_compare/mask_gripper_trapezoid.py <schemes或episode目录>
+python3 schemes_compare/mask_gripper_trapezoid.py <schemes/session/episode目录>
 ```
+输入 schemes 目录时读取 `episode_*/raw/`；输入普通 session 或单个 episode 时读取
+episode 根目录。掩膜结果统一写到 `episode_*/maskgripper/`，运行 ORB 时应把该子目录
+作为输入。
 梯形顶点（夹爪与相机刚性连接，画面里固定，只有手指开合；已跨两台设备验证通用）：
 - 左眼：[(236,292),(417,292),(525,467),(127,467)]（顶左→顶右→底右→底左）+ rows≥467 全宽黑
 - 右眼：[(182,292),(365,292),(444,467),(46,467)] + rows≥467 全宽黑
@@ -53,5 +56,6 @@ python3 schemes_compare/aggregate_schemes.py
 
 ## 注意
 - `T_CAM_EE`（相机→夹爪指尖变换，在 `visualization/visualize_traj_video.py`）是按本装置实测重标定的（指尖 +0.145m 前/−0.030m 下、pitch −30°）。换装置请核验绿点是否落夹爪中心。
-- 脚本里的数据路径是示例（默认 `/home/ss/data/1000_onesb_labpicking`），用 `MASK_DATA` 环境变量或改 `BASE` 适配你的机器。
+- 脚本里的数据路径是示例（默认 `/home/ss/data/1000_onesb_labpicking`）；可用 `MASK_DATA` 环境变量覆盖，`aggregate_schemes.py` 也接受 data-root 位置参数。
+- `run_orb_scheme.py` 默认使用 `~/code/ORB_SLAM3`；可用 `ORB_SLAM3_DIR` 或 `--orbslam-dir` 覆盖。
 - Vive 动捕在遮挡时会出错，不能盲信当真值；用前需识别并剔除被遮挡 episode。

--- a/schemes_compare/README.md
+++ b/schemes_compare/README.md
@@ -1,0 +1,57 @@
+# schemes_compare — 遮罩方案对比 (raw / maskhalf / maskgripper)
+
+对比三种 ORB-SLAM3 前处理遮罩方案对轨迹还原的影响，并给出生产方案。
+
+## 结论（287 集，4 个 Vive + 2 个无 Vive session 验证）
+
+| 方案 | 说明 | 结果 |
+|---|---|---|
+| `raw` | 不遮 | 大量坍缩（轨迹缩成真实运动零头），**不可用** |
+| `maskhalf` | 底部 38/97 涂黑 (cutoff=292) | 修好坍缩，但偶有跟丢 |
+| `maskgripper` | **只遮夹爪梯形**（左右红外各一套顶点 + 底部 13 行） | **质量等价 + 跟踪更稳** |
+
+**数据**（以 maskhalf 为基准，纯方法间对比，不依赖 Vive）：
+- 质量：两边都跟全的 278 集，maskgripper vs maskhalf 偏差中位 **0.5mm**（亚毫米，等价）。
+- 稳健性：maskhalf 跟丢 9 集，maskgripper 跟丢 5 集；**maskgripper 救回 4 集** maskhalf 跟丢的。
+- → **生产默认用 `maskgripper`**（保留更多特征 → ORB 不易丢跟踪；额外成本仅涂黑步骤略复杂）。
+
+根因：画面底部的夹爪 + AprilTag 是高对比、会动的"毒特征"，破坏 ORB-SLAM 静态场景假设。基线/标定没问题（D405 18mm 基线本就对）。
+
+## 生产用法（处理新数据）
+
+跑 ORB-SLAM 前，对每个 episode 的 left_/right_ 涂黑夹爪梯形：
+```bash
+python3 schemes_compare/mask_gripper_trapezoid.py <schemes或episode目录>
+```
+梯形顶点（夹爪与相机刚性连接，画面里固定，只有手指开合；已跨两台设备验证通用）：
+- 左眼：[(236,292),(417,292),(525,467),(127,467)]（顶左→顶右→底右→底左）+ rows≥467 全宽黑
+- 右眼：[(182,292),(365,292),(444,467),(46,467)] + rows≥467 全宽黑
+- 左眼夹爪居中→对称；右眼因立体视差左移 ~48px，故左右眼顶点不同。
+
+## 完整对比流程（复现 mg≥mh）
+
+```bash
+# 1) 一个 session 全量做成 schemes(raw/maskhalf/maskgripper 各跑 ORB)
+MASK_DATA=/path/to/data bash schemes_compare/build_session_schemes.sh 20260709_XXXXXX
+# 2) 坐标变换(投影回RGB必需)
+python3 transform_trajectory.py <session>-schemes --recursive
+# 3) 三面板对比视频(每episode raw|maskhalf|maskgripper 并排)
+python3 schemes_compare/viz_scheme_compare.py <session>-schemes
+# 4) 完整度+偏差(以maskhalf为基准)
+python3 schemes_compare/deviation_vs_baseline.py <session>-schemes
+# 5) 跨session总表
+python3 schemes_compare/aggregate_schemes.py
+```
+输出在 `<session>-schemes/_compare/`（视频 + deviation.csv）。
+
+## 文件说明
+- `mask_gripper_trapezoid.py` — **生产掩膜**（mg）。`mask_session.py` — maskhalf（cutoff=292，对比用）。
+- `schemes_init.py` / `build_session_schemes.sh` / `run_orb_scheme.py` — schemes 结构搭建 + 批量 ORB。
+- `viz_scheme_compare.py` — 三面板对比视频（复用 `visualization/visualize_traj_video.py` 的投影）。
+- `deviation_vs_baseline.py` / `aggregate_schemes.py` — 完整度(输出帧/输入帧，丢帧=失败) + 偏差分析。
+- `orb_vs_vive.py` — ORB vs Vive 动捕真值 Sim3 对齐（Vive 准的时候用）。
+
+## 注意
+- `T_CAM_EE`（相机→夹爪指尖变换，在 `visualization/visualize_traj_video.py`）是按本装置实测重标定的（指尖 +0.145m 前/−0.030m 下、pitch −30°）。换装置请核验绿点是否落夹爪中心。
+- 脚本里的数据路径是示例（默认 `/home/ss/data/1000_onesb_labpicking`），用 `MASK_DATA` 环境变量或改 `BASE` 适配你的机器。
+- Vive 动捕在遮挡时会出错，不能盲信当真值；用前需识别并剔除被遮挡 episode。

--- a/schemes_compare/aggregate_schemes.py
+++ b/schemes_compare/aggregate_schemes.py
@@ -3,12 +3,18 @@
 每方案 失败集数(丢帧)/完整度 + maskhalf丢而maskgripper全 + 质量(两边跟全的偏差)。
 用法: python3 aggregate_schemes.py
 """
-import csv, glob
+import argparse, csv, glob, os
 from pathlib import Path
 import numpy as np
 
-base = Path("/home/ss/data/1000_onesb_labpicking")
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("data_root", nargs="?", type=Path,
+                    default=Path(os.environ.get("MASK_DATA", "/home/ss/data/1000_onesb_labpicking")))
+args = parser.parse_args()
+base = args.data_root.resolve()
 csvs = sorted(glob.glob(str(base / "*-schemes/_compare/deviation.csv")))
+if not csvs:
+    raise SystemExit(f"no deviation.csv files found under {base}")
 f = lambda x: float(x) if x not in (None, "NA", "") else None
 
 print(f"sessions: {len(csvs)}\n")
@@ -22,16 +28,18 @@ for c in csvs:
     sdev = []
     for r in rows:
         nin = f(r["nin"]); mh = f(r["maskhalf_n"]); mg = f(r["maskgripper_n"])
-        if nin and mh and mh < nin: mh_fail += 1
-        if nin and mg and mg < nin: mg_fail += 1
-        if nin and mh < nin and mg >= nin: saved += 1
-        if nin and mh == nin and mg == nin:  # 两边都跟全 → 质量可比
+        if nin is not None and mh is not None and mh < nin: mh_fail += 1
+        if nin is not None and mg is not None and mg < nin: mg_fail += 1
+        if (nin is not None and mh is not None and mg is not None
+                and mh < nin and mg >= nin): saved += 1
+        if nin is not None and mh == nin and mg == nin:  # 两边都跟全 → 质量可比
             d = f(r["rmse_mg_vs_mh_mm"])
-            if d: sdev.append(d)
+            if d is not None: sdev.append(d)
     dev_med = np.median(sdev) if sdev else float("nan")
     print(f"{sess:<16}{len(rows):>4}{mh_fail:>7}{mg_fail:>7}{saved:>9}{dev_med:>9.1f}mm")
     tot_eps += len(rows); tot_mh += mh_fail; tot_mg += mg_fail; tot_saved += saved; both_dev += sdev
 
-print(f"{'TOTAL':<16}{tot_eps:>4}{tot_mh:>7}{tot_mg:>7}{tot_saved:>9}{np.median(both_dev):>9.1f}mm")
+overall_med = np.median(both_dev) if both_dev else float("nan")
+print(f"{'TOTAL':<16}{tot_eps:>4}{tot_mh:>7}{tot_mg:>7}{tot_saved:>9}{overall_med:>9.1f}mm")
 print(f"\n总结: {tot_eps} 集 | maskhalf 失败 {tot_mh} | maskgripper 失败 {tot_mg} | maskgripper 救回(maskhalf丢它全) {tot_saved}")
-print(f"质量(两边都跟全, n={len(both_dev)}): maskgripper vs maskhalf 偏差中位 {np.median(both_dev):.1f}mm → 等价")
+print(f"质量(两边都跟全, n={len(both_dev)}): maskgripper vs maskhalf 偏差中位 {overall_med:.1f}mm → 等价")

--- a/schemes_compare/aggregate_schemes.py
+++ b/schemes_compare/aggregate_schemes.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""汇总所有 *-schemes 的偏差表 → 跨 session 总表：
+每方案 失败集数(丢帧)/完整度 + maskhalf丢而maskgripper全 + 质量(两边跟全的偏差)。
+用法: python3 aggregate_schemes.py
+"""
+import csv, glob
+from pathlib import Path
+import numpy as np
+
+base = Path("/home/ss/data/1000_onesb_labpicking")
+csvs = sorted(glob.glob(str(base / "*-schemes/_compare/deviation.csv")))
+f = lambda x: float(x) if x not in (None, "NA", "") else None
+
+print(f"sessions: {len(csvs)}\n")
+print(f"{'session':<16}{'eps':>4}{'mh失败':>7}{'mg失败':>7}{'mh丢mg全':>9}{'mg-mh偏差':>10}")
+tot_eps = tot_mh = tot_mg = tot_saved = 0
+both_dev = []
+for c in csvs:
+    sess = Path(c).parents[1].name.replace("-schemes", "")
+    rows = list(csv.DictReader(open(c)))
+    mh_fail = mg_fail = saved = 0
+    sdev = []
+    for r in rows:
+        nin = f(r["nin"]); mh = f(r["maskhalf_n"]); mg = f(r["maskgripper_n"])
+        if nin and mh and mh < nin: mh_fail += 1
+        if nin and mg and mg < nin: mg_fail += 1
+        if nin and mh < nin and mg >= nin: saved += 1
+        if nin and mh == nin and mg == nin:  # 两边都跟全 → 质量可比
+            d = f(r["rmse_mg_vs_mh_mm"])
+            if d: sdev.append(d)
+    dev_med = np.median(sdev) if sdev else float("nan")
+    print(f"{sess:<16}{len(rows):>4}{mh_fail:>7}{mg_fail:>7}{saved:>9}{dev_med:>9.1f}mm")
+    tot_eps += len(rows); tot_mh += mh_fail; tot_mg += mg_fail; tot_saved += saved; both_dev += sdev
+
+print(f"{'TOTAL':<16}{tot_eps:>4}{tot_mh:>7}{tot_mg:>7}{tot_saved:>9}{np.median(both_dev):>9.1f}mm")
+print(f"\n总结: {tot_eps} 集 | maskhalf 失败 {tot_mh} | maskgripper 失败 {tot_mg} | maskgripper 救回(maskhalf丢它全) {tot_saved}")
+print(f"质量(两边都跟全, n={len(both_dev)}): maskgripper vs maskhalf 偏差中位 {np.median(both_dev):.1f}mm → 等价")

--- a/schemes_compare/build_session_schemes.sh
+++ b/schemes_compare/build_session_schemes.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# 把一个 session 全量做成 schemes 结构：raw / maskhalf / maskgripper 各跑 ORB。
+# 中间产物 -png / -png-mask292 在并入 schemes 后删除（保持整洁）。
+# 用法: bash build_session_schemes.sh <session-basename>   例: 20260709_144719
+set -e
+B="$1"
+BASE="${MASK_DATA:-/home/ss/data/1000_onesb_labpicking}"
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+VIZ="$(cd "$(dirname "$0")" && pwd)"
+MP4="$BASE/$B-mp4"; PNG="$BASE/$B-png"; MASK="$BASE/$B-png-mask292"; SCH="$BASE/$B-schemes"
+
+echo "### 1) decode $B"
+conda run -n lerobot --no-capture-output python "$REPO/decode_videos.py" "$MP4" --recursive
+
+echo "### 2) mask half (cutoff=292)"
+python3 "$VIZ/mask_session.py" "$PNG" 292
+
+echo "### 3) schemes init (raw + maskhalf)"
+python3 "$VIZ/schemes_init.py" "$PNG" "$MASK" "$SCH"
+
+echo "### 4) 删冗余 -png / -png-mask292 (内容已并入 schemes)"
+rm -rf "$PNG" "$MASK"
+
+echo "### 5) maskgripper 梯形掩膜"
+python3 "$VIZ/mask_gripper_trapezoid.py" "$SCH"
+
+echo "### 6) ORB: raw / maskhalf / maskgripper"
+for sch in raw maskhalf maskgripper; do
+  python3 "$VIZ/run_orb_scheme.py" "$SCH" "$sch"
+done
+
+echo "=== $B schemes 全部完成 → $SCH ==="

--- a/schemes_compare/deviation_vs_baseline.py
+++ b/schemes_compare/deviation_vs_baseline.py
@@ -18,7 +18,13 @@ def loadt(ep, sch):
     t = ep / sch / "CameraTrajectoryTransformed.txt"
     if not t.exists():
         t = ep / sch / "CameraTrajectory.txt"
-    return ovv.load_kitti_positions(t) if t.exists() else None
+    if not t.exists():
+        return None
+    try:
+        points = ovv.load_kitti_positions(t)
+    except (OSError, ValueError):
+        return None
+    return points if len(points) else None
 
 
 def ninput(ep):
@@ -32,7 +38,7 @@ def ninput(ep):
 
 
 def dev(A, B):
-    if A is None or B is None:
+    if A is None or B is None or len(A) == 0 or len(B) == 0:
         return None
     if len(A) != len(B):
         L = min(len(A), len(B))
@@ -49,9 +55,8 @@ rows = []
 for ep in eps:
     ni = ninput(ep)
     base = loadt(ep, "maskhalf"); mg = loadt(ep, "maskgripper"); raw = loadt(ep, "raw")
-    if base is None:
-        continue
-    rows.append(dict(ep=ep.name, nin=ni, mh_n=len(base), mg_n=len(mg) if mg is not None else 0,
+    rows.append(dict(ep=ep.name, nin=ni, mh_n=len(base) if base is not None else 0,
+                     mg_n=len(mg) if mg is not None else 0,
                      raw_n=len(raw) if raw is not None else 0, d_mg=dev(mg, base), d_raw=dev(raw, base),
                      mh_bbox=bbox(base), mg_bbox=bbox(mg)))
 
@@ -63,21 +68,28 @@ with open(csvp, "w", newline="") as f:
                 "rmse_mg_vs_mh_mm", "rmse_raw_vs_mh_mm", "mh_bbox_cm", "mg_bbox_cm"])
     for r in rows:
         w.writerow([r["ep"], r["nin"], r["mh_n"], r["mg_n"], r["raw_n"],
-                    f"{r['d_mg']*1000:.1f}" if r["d_mg"] else "NA",
-                    f"{r['d_raw']*1000:.1f}" if r["d_raw"] else "NA",
+                    f"{r['d_mg']*1000:.1f}" if r["d_mg"] is not None else "NA",
+                    f"{r['d_raw']*1000:.1f}" if r["d_raw"] is not None else "NA",
                     f"{r['mh_bbox']*100:.1f}", f"{r['mg_bbox']*100:.1f}"])
 
 comp = lambda r, k: (100 * r[k] / r["nin"]) if r["nin"] else 0
 mh_c = np.array([comp(r, "mh_n") for r in rows])
 mg_c = np.array([comp(r, "mg_n") for r in rows])
 print(f"{schemes.name}: n={len(rows)}  (thr={thr}mm)")
-print(f"  跟踪完整度: maskhalf mean={mh_c.mean():.0f}% (丢帧={int((mh_c < 100).sum())}) | "
-      f"maskgripper mean={mg_c.mean():.0f}% (丢帧={int((mg_c < 100).sum())})")
+if rows:
+    print(f"  跟踪完整度: maskhalf mean={mh_c.mean():.0f}% (丢帧={int((mh_c < 100).sum())}) | "
+          f"maskgripper mean={mg_c.mean():.0f}% (丢帧={int((mg_c < 100).sum())})")
+else:
+    print("  跟踪完整度: no episodes")
 lost = [r for r in rows if r["nin"] and r["mh_n"] < r["nin"] and r["mg_n"] >= r["nin"]]
 print(f"  ★ maskhalf丢帧 而 maskgripper跟全 的 episode: {len(lost)} 个")
 for r in lost:
     print(f"      {r['ep']}: maskhalf {r['mh_n']}/{r['nin']}  maskgripper {r['mg_n']}/{r['nin']}")
-mg = np.array([r["d_mg"] for r in rows if r["d_mg"]])
-ra = np.array([r["d_raw"] for r in rows if r["d_raw"]])
-print(f"  偏差: maskgripper vs maskhalf med={np.median(mg)*1000:.1f}mm | raw vs maskhalf med={np.median(ra)*1000:.1f}mm")
+mg = np.array([r["d_mg"] for r in rows if r["d_mg"] is not None])
+ra = np.array([r["d_raw"] for r in rows if r["d_raw"] is not None])
+mg_med = np.median(mg) * 1000 if len(mg) else float("nan")
+ra_med = np.median(ra) * 1000 if len(ra) else float("nan")
+over_thr = int((mg * 1000 > thr).sum()) if len(mg) else 0
+print(f"  偏差: maskgripper vs maskhalf med={mg_med:.1f}mm (>{thr:g}mm: {over_thr}) | "
+      f"raw vs maskhalf med={ra_med:.1f}mm")
 print(f"CSV: {csvp}")

--- a/schemes_compare/deviation_vs_baseline.py
+++ b/schemes_compare/deviation_vs_baseline.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""以 maskhalf 为基准，对比 maskgripper/raw 的：① 轨迹偏差(刚体RMSE) ② 跟踪完整度(输出帧/输入帧)。
+找 maskhalf 丢帧而 maskgripper 跟全 的 episode(说明遮夹爪更稳)。无需 Vive。
+用法: python deviation_vs_baseline.py <schemes_dir> [thr_mm=15]
+"""
+import sys, csv
+from pathlib import Path
+import numpy as np
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import orb_vs_vive as ovv
+
+schemes = Path(sys.argv[1])
+thr = float(sys.argv[2]) if len(sys.argv) > 2 else 15.0
+eps = sorted(d for d in schemes.iterdir() if d.is_dir() and d.name.startswith("episode_"))
+
+
+def loadt(ep, sch):
+    t = ep / sch / "CameraTrajectoryTransformed.txt"
+    if not t.exists():
+        t = ep / sch / "CameraTrajectory.txt"
+    return ovv.load_kitti_positions(t) if t.exists() else None
+
+
+def ninput(ep):
+    t = ep / "times.txt"
+    if t.exists():
+        try:
+            return int(len(np.loadtxt(t).reshape(-1)))
+        except Exception:
+            pass
+    return None
+
+
+def dev(A, B):
+    if A is None or B is None:
+        return None
+    if len(A) != len(B):
+        L = min(len(A), len(B))
+        A, B = ovv.resample_to_length(A, L), ovv.resample_to_length(B, L)
+    s, R, t = ovv.umeyama(A, B, with_scale=False)
+    return float(np.sqrt(np.mean(np.sum(((R @ A.T).T + t - B) ** 2, axis=1))))
+
+
+def bbox(P):
+    return float(np.linalg.norm(P.max(0) - P.min(0))) if P is not None and len(P) else 0.0
+
+
+rows = []
+for ep in eps:
+    ni = ninput(ep)
+    base = loadt(ep, "maskhalf"); mg = loadt(ep, "maskgripper"); raw = loadt(ep, "raw")
+    if base is None:
+        continue
+    rows.append(dict(ep=ep.name, nin=ni, mh_n=len(base), mg_n=len(mg) if mg is not None else 0,
+                     raw_n=len(raw) if raw is not None else 0, d_mg=dev(mg, base), d_raw=dev(raw, base),
+                     mh_bbox=bbox(base), mg_bbox=bbox(mg)))
+
+outdir = schemes / "_compare"; outdir.mkdir(exist_ok=True)
+csvp = outdir / "deviation.csv"
+with open(csvp, "w", newline="") as f:
+    w = csv.writer(f)
+    w.writerow(["episode", "nin", "maskhalf_n", "maskgripper_n", "raw_n",
+                "rmse_mg_vs_mh_mm", "rmse_raw_vs_mh_mm", "mh_bbox_cm", "mg_bbox_cm"])
+    for r in rows:
+        w.writerow([r["ep"], r["nin"], r["mh_n"], r["mg_n"], r["raw_n"],
+                    f"{r['d_mg']*1000:.1f}" if r["d_mg"] else "NA",
+                    f"{r['d_raw']*1000:.1f}" if r["d_raw"] else "NA",
+                    f"{r['mh_bbox']*100:.1f}", f"{r['mg_bbox']*100:.1f}"])
+
+comp = lambda r, k: (100 * r[k] / r["nin"]) if r["nin"] else 0
+mh_c = np.array([comp(r, "mh_n") for r in rows])
+mg_c = np.array([comp(r, "mg_n") for r in rows])
+print(f"{schemes.name}: n={len(rows)}  (thr={thr}mm)")
+print(f"  跟踪完整度: maskhalf mean={mh_c.mean():.0f}% (丢帧={int((mh_c < 100).sum())}) | "
+      f"maskgripper mean={mg_c.mean():.0f}% (丢帧={int((mg_c < 100).sum())})")
+lost = [r for r in rows if r["nin"] and r["mh_n"] < r["nin"] and r["mg_n"] >= r["nin"]]
+print(f"  ★ maskhalf丢帧 而 maskgripper跟全 的 episode: {len(lost)} 个")
+for r in lost:
+    print(f"      {r['ep']}: maskhalf {r['mh_n']}/{r['nin']}  maskgripper {r['mg_n']}/{r['nin']}")
+mg = np.array([r["d_mg"] for r in rows if r["d_mg"]])
+ra = np.array([r["d_raw"] for r in rows if r["d_raw"]])
+print(f"  偏差: maskgripper vs maskhalf med={np.median(mg)*1000:.1f}mm | raw vs maskhalf med={np.median(ra)*1000:.1f}mm")
+print(f"CSV: {csvp}")

--- a/schemes_compare/mask_gripper_trapezoid.py
+++ b/schemes_compare/mask_gripper_trapezoid.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""方案3 掩膜：夹爪梯形(整段固定，左右红外各一套顶点) + 底部467行及以下全黑。
+读 <schemes>/episode_NNN/raw/{left_,right_} 原图 → 写 maskgripper/{left_,right_}。
+用法: python3 mask_gripper_trapezoid.py <schemes_dir>
+"""
+import sys, os
+from pathlib import Path
+import cv2
+import numpy as np
+
+# 顺序: 顶左 → 顶右 → 底右 → 底左 (凸梯形, 不自交)
+LEFT_POLY  = np.array([[(236, 292), (417, 292), (525, 467), (127, 467)]], dtype=np.int32)
+RIGHT_POLY = np.array([[(182, 292), (365, 292), (444, 467), ( 46, 467)]], dtype=np.int32)
+BOTTOM_ROW = 467  # 该行及以下全部涂黑
+
+
+def apply_mask(img, poly):
+    out = img.copy()
+    cv2.fillPoly(out, poly, 0)     # 梯形涂黑
+    out[BOTTOM_ROW:] = 0           # 底部条带全宽涂黑
+    return out
+
+
+schemes = Path(sys.argv[1])
+eps = sorted(d for d in schemes.iterdir() if d.is_dir() and d.name.startswith("episode_"))
+for ep in eps:
+    raw = ep / "raw"
+    mg = ep / "maskgripper"
+    mg.mkdir(exist_ok=True)
+    for s in ["times.txt", "orb_slam_realsense_d405.yaml"]:   # symlink 共享文件
+        link = mg / s
+        if not link.exists():
+            os.symlink(f"../{s}", link)
+    nl = nr = 0
+    for p in sorted(raw.glob("left_*.png")):
+        cv2.imwrite(str(mg / p.name), apply_mask(cv2.imread(str(p)), LEFT_POLY));  nl += 1
+    for p in sorted(raw.glob("right_*.png")):
+        cv2.imwrite(str(mg / p.name), apply_mask(cv2.imread(str(p)), RIGHT_POLY)); nr += 1
+    print(f"  {ep.name}: {nl}L {nr}R", flush=True)
+print(f"done → {schemes} ({len(eps)} episodes)")

--- a/schemes_compare/mask_gripper_trapezoid.py
+++ b/schemes_compare/mask_gripper_trapezoid.py
@@ -15,26 +15,43 @@ BOTTOM_ROW = 467  # 该行及以下全部涂黑
 
 
 def apply_mask(img, poly):
+    if img is None:
+        raise ValueError("cannot mask an unreadable image")
     out = img.copy()
     cv2.fillPoly(out, poly, 0)     # 梯形涂黑
     out[BOTTOM_ROW:] = 0           # 底部条带全宽涂黑
     return out
 
 
-schemes = Path(sys.argv[1])
-eps = sorted(d for d in schemes.iterdir() if d.is_dir() and d.name.startswith("episode_"))
+input_path = Path(sys.argv[1]).resolve()
+if not input_path.is_dir():
+    raise SystemExit(f"directory not found: {input_path}")
+if input_path.name.startswith("episode_"):
+    eps = [input_path]
+else:
+    eps = sorted(d for d in input_path.iterdir() if d.is_dir() and d.name.startswith("episode_"))
+if not eps:
+    raise SystemExit(f"no episode_* directories found under: {input_path}")
 for ep in eps:
-    raw = ep / "raw"
+    raw = ep / "raw" if (ep / "raw").is_dir() else ep
     mg = ep / "maskgripper"
     mg.mkdir(exist_ok=True)
-    for s in ["times.txt", "orb_slam_realsense_d405.yaml"]:   # symlink 共享文件
-        link = mg / s
-        if not link.exists():
-            os.symlink(f"../{s}", link)
-    nl = nr = 0
-    for p in sorted(raw.glob("left_*.png")):
-        cv2.imwrite(str(mg / p.name), apply_mask(cv2.imread(str(p)), LEFT_POLY));  nl += 1
-    for p in sorted(raw.glob("right_*.png")):
-        cv2.imwrite(str(mg / p.name), apply_mask(cv2.imread(str(p)), RIGHT_POLY)); nr += 1
+    shared = [ep / "times.txt", *sorted(ep.glob("orb_slam_*.yaml"))]
+    for source in shared:
+        link = mg / source.name
+        if source.exists() and not link.exists():
+            os.symlink(f"../{source.name}", link)
+    left = sorted(raw.glob("left_*.png"))
+    right = sorted(raw.glob("right_*.png"))
+    if not left or not right:
+        raise RuntimeError(f"missing stereo PNG images in {raw}")
+    for path, poly in [(p, LEFT_POLY) for p in left] + [(p, RIGHT_POLY) for p in right]:
+        image = cv2.imread(str(path), cv2.IMREAD_UNCHANGED)
+        if image is None:
+            raise RuntimeError(f"failed to read image: {path}")
+        output = mg / path.name
+        if not cv2.imwrite(str(output), apply_mask(image, poly)):
+            raise RuntimeError(f"failed to write image: {output}")
+    nl, nr = len(left), len(right)
     print(f"  {ep.name}: {nl}L {nr}R", flush=True)
-print(f"done → {schemes} ({len(eps)} episodes)")
+print(f"done → {input_path} ({len(eps)} episodes)")

--- a/schemes_compare/mask_session.py
+++ b/schemes_compare/mask_session.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""把整个 session 所有 episode 的图像底部涂黑。原图不动，写到 -mask<cutoff>/。
+
+用法: python mask_session.py <png_session> <cutoff_row>
+例:   python mask_session.py .../20260709_144418-png 292
+      (第 292 行及以下涂黑；对应去掉底部 38/97 ≈ 39%)
+"""
+import sys, shutil
+from pathlib import Path
+import cv2
+
+
+def main():
+    src = Path(sys.argv[1]).resolve()
+    cutoff = int(sys.argv[2])
+    dst = src.parent / f"{src.name}-mask{cutoff}"
+    eps = sorted(d for d in src.iterdir() if d.is_dir() and d.name.startswith("episode_"))
+    print(f"{src.name}: {len(eps)} episodes, cutoff={cutoff} (第{cutoff}行及以下涂黑) → {dst.name}")
+    for i, ep in enumerate(eps, 1):
+        d = dst / ep.name
+        d.mkdir(parents=True, exist_ok=True)
+        for name in ["orb_slam_realsense_d405.yaml", "times.txt", "timestamps.json",
+                     "camera_info_left.json", "camera_info_right.json", "camera_info_color.json"]:
+            s = ep / name
+            if s.exists():
+                shutil.copy2(s, d / name)
+        for pat in ["left_*.png", "right_*.png", "color_*.png"]:
+            for p in sorted(ep.glob(pat)):
+                img = cv2.imread(str(p), cv2.IMREAD_UNCHANGED)
+                if img is None:
+                    continue
+                img[cutoff:, ...] = 0
+                cv2.imwrite(str(d / p.name), img)
+        print(f"  [{i}/{len(eps)}] {ep.name}", flush=True)
+    print(f"done → {dst}")
+
+
+if __name__ == "__main__":
+    main()

--- a/schemes_compare/orb_vs_vive.py
+++ b/schemes_compare/orb_vs_vive.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""
+ORB-SLAM 轨迹 vs Vive 动捕真值：对齐 + 量尺度。
+
+每个 episode：
+  - CameraTrajectory.txt  (ORB-SLAM3 KITTI 输出, 在 -png 目录)   → 相机估计位姿
+  - vive_poses.jsonl      (Vive 动捕, ~240Hz, 在 -mp4 目录)       → 真值位姿
+  - times.txt             (相机帧 UNIX 时间戳, 在 -mp4 目录)
+
+做法：
+  1. 把 Vive 按时间插值到相机帧时刻 → 得到与相机帧一一对应的 Vive 真值位置。
+  2. ORB 帧数 M 与相机帧数 N 若不等(ORB 丢帧)，按"归一化进度"重采样两者到等长，
+     再做 Umeyama Sim3 对齐（只对位置）。s = 把 ORB 缩放到匹配 Vive 的因子。
+       s≈1 → 尺度一致；s>1 → ORB 偏小(基线偏小)；s<1 → ORB 偏大。
+  3. 另算一个不依赖对应的 bbox 对角线之比，交叉验证 s。
+
+输出（写到 <png_session>_orbviz/）：
+  - 每个 episode 一个交互式 HTML：Vive(红) + ORB刚体对齐(蓝,不缩放) + ORB缩放对齐(绿)
+  - summary.csv：每行一个 episode 的 s / RMSE / 路径长 / bbox 比 / 帧数
+
+用法：
+  python orb_vs_vive.py <png_session目录>
+  (自动把路径里的 -png 换成 -mp4 找 Vive/times)
+"""
+import sys, json, csv
+from pathlib import Path
+import numpy as np
+
+
+def load_kitti_positions(p):
+    """KITTI 轨迹每行 12 个数 = 3x4 [R|t] 行优先；取第 4/8/12 列即平移。"""
+    a = np.atleast_2d(np.loadtxt(p))
+    if a.shape[1] == 13:
+        a = a[:, 1:]
+    a = a.reshape(-1, 3, 4)
+    return a[:, :3, 3]              # (M,3)
+
+
+def load_vive(p):
+    times, pos = [], []
+    with open(p) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            d = json.loads(line)
+            times.append(d["time"])
+            pos.append(d["pos"])
+    return np.array(times), np.array(pos)   # (K,) (K,3)
+
+
+def load_times(p):
+    return np.loadtxt(p).reshape(-1)        # (N,)
+
+
+def umeyama(model, data, with_scale=True):
+    """对齐 model→data：返回 (s,R,t)，使 data ≈ (s·R·model + t)。"""
+    mu_m = model.mean(0); mu_d = data.mean(0)
+    mz = model - mu_m; dz = data - mu_d
+    n = len(model)
+    H = mz.T @ dz / n
+    U, S, Vt = np.linalg.svd(H)
+    D = np.eye(3)
+    if np.linalg.det(U @ Vt) < 0:
+        D[2, 2] = -1
+    R = Vt.T @ D @ U.T
+    if with_scale:
+        var_m = np.sum(np.var(model, axis=0))
+        s = np.trace(np.diag(S) @ D) / var_m if var_m > 1e-12 else 1.0
+    else:
+        s = 1.0
+    t = mu_d - s * R @ mu_m
+    return s, R, t
+
+
+def resample_to_length(P, L):
+    """把 (n,3) 轨迹按弧长(或索引)重采样到 L 个点，做点对点对应用。"""
+    n = len(P)
+    if n == L:
+        return P
+    idx = np.linspace(0, n - 1, L)
+    return np.column_stack([np.interp(idx, np.arange(n), P[:, d]) for d in range(3)])
+
+
+def bbox_diag(P):
+    return float(np.linalg.norm(P.max(0) - P.min(0)))
+
+
+def path_len(P):
+    return float(np.sum(np.linalg.norm(np.diff(P, axis=0), axis=1)))
+
+
+def process_episode(orb_txt, vive_jsonl, times_txt, out_html, name):
+    P_orb = load_kitti_positions(orb_txt)                 # (M,3)
+    T_vive, P_vive_full = load_vive(vive_jsonl)           # (K,),(K,3)
+    T_cam = load_times(times_txt)                         # (N,)
+
+    # Vive 插值到相机帧时刻（越界 → nan）
+    Pv_at_cam = np.column_stack([
+        np.interp(T_cam, T_vive, P_vive_full[:, d],
+                  left=np.nan, right=np.nan) for d in range(3)])  # (N,3)
+    good = np.isfinite(Pv_at_cam).all(1)
+    Pv = Pv_at_cam[good]
+    # ORB 与相机帧数对应：若相等直接配对；不等则按等长重采样（假设都覆盖整段）
+    if len(P_orb) == len(Pv):
+        A, B = P_orb, Pv
+    else:
+        L = min(len(P_orb), len(Pv))
+        A = resample_to_length(P_orb, L)
+        B = resample_to_length(Pv, L)
+
+    # 刚体对齐(不缩放) + Sim3(缩放)
+    s1, R1, t1 = umeyama(A, B, with_scale=False)
+    s, R, t = umeyama(A, B, with_scale=True)
+    A_rigid = (R1 @ A.T).T + t1                 # 蓝色：只对齐姿态，保留 ORB 原尺度
+    A_scaled = (s * (R @ A.T).T) + t            # 绿色：缩放后应与 Vive 重合
+    rmse = float(np.sqrt(np.mean(np.sum((A_scaled - B) ** 2, axis=1))))
+
+    # 不依赖对应的尺度交叉验证
+    diag_orb = bbox_diag(P_orb); diag_vive = bbox_diag(Pv)
+    bbox_ratio = diag_orb / diag_vive if diag_vive > 1e-9 else float("nan")
+
+    # ---- 交互式 HTML ----
+    if out_html is not None:
+        try:
+            import plotly.graph_objects as go
+            fig = go.Figure()
+            fig.add_trace(go.Scatter3d(x=B[:, 0], y=B[:, 1], z=B[:, 2], mode="lines+markers",
+                                       line=dict(width=4, color="red"), marker=dict(size=3),
+                                       name=f"Vive 真值 ({len(B)})"))
+            fig.add_trace(go.Scatter3d(x=A_rigid[:, 0], y=A_rigid[:, 1], z=A_rigid[:, 2], mode="lines",
+                                       line=dict(width=3, color="blue"), name="ORB 刚体对齐(不缩放)"))
+            fig.add_trace(go.Scatter3d(x=A_scaled[:, 0], y=A_scaled[:, 1], z=A_scaled[:, 2], mode="lines",
+                                       line=dict(width=3, color="green"), name=f"ORB 缩放对齐 (s={s:.3f})"))
+            fig.update_layout(
+                title=(f"{name} | M_ORB={len(P_orb)} N_cam={len(T_cam)} | "
+                       f"Sim3 s={s:.3f}  RMSE={rmse*1000:.1f}mm | bbox比={bbox_ratio:.2f}"),
+                scene=dict(xaxis_title="X", yaxis_title="Y", zaxis_title="Z", aspectmode="data"),
+                width=980, height=760)
+            fig.write_html(out_html)
+        except Exception as e:
+            print(f"  (HTML 跳过 {name}: {e})")
+
+    return dict(episode=name, M_orb=len(P_orb), N_cam=len(T_cam), n_pairs=len(A),
+                sim3_scale=s, rmse_mm=rmse * 1000, path_orb=path_len(P_orb),
+                path_vive=path_len(Pv), bbox_ratio=bbox_ratio)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__); sys.exit(1)
+    args = [a for a in sys.argv[1:] if a != "--no-html"]
+    png_session = Path(args[0]).resolve()
+    if len(args) > 1:
+        mp4_session = Path(args[1]).resolve()              # 显式指定 -mp4（掩膜衍生目录用）
+    else:
+        mp4_session = Path(str(png_session).replace("-png", "-mp4"))
+    if not mp4_session.exists():
+        print(f"-mp4 目录不存在: {mp4_session}"); sys.exit(1)
+
+    outdir = png_session.parent / (png_session.name.replace("-png", "-orbviz"))
+    outdir.mkdir(exist_ok=True)
+    no_html = "--no-html" in sys.argv
+
+    eps = sorted(d for d in png_session.iterdir() if d.is_dir() and d.name.startswith("episode_"))
+    print(f"{png_session.name}: {len(eps)} episodes  →  {outdir}\n")
+
+    rows = []
+    for ep in eps:
+        orb_txt = ep / "CameraTrajectory.txt"
+        vive = mp4_session / ep.name / "vive_poses.jsonl"
+        times = mp4_session / ep.name / "times.txt"
+        if not orb_txt.exists():
+            print(f"  {ep.name}: 无 CameraTrajectory.txt (ORB 没跑/失败)，跳过")
+            continue
+        if not vive.exists() or not times.exists():
+            print(f"  {ep.name}: 缺 Vive/times，跳过")
+            continue
+        html = None if no_html else outdir / f"{ep.name}.html"
+        try:
+            r = process_episode(orb_txt, vive, times, html, ep.name)
+            rows.append(r)
+            print(f"  {ep.name}: s={r['sim3_scale']:.3f}  RMSE={r['rmse_mm']:.1f}mm  "
+                  f"bbox比={r['bbox_ratio']:.2f}  (M={r['M_orb']} N={r['N_cam']})")
+        except Exception as e:
+            print(f"  {ep.name}: 出错 {e}")
+
+    if rows:
+        csvp = outdir / "summary.csv"
+        with open(csvp, "w", newline="") as f:
+            w = csv.DictWriter(f, fieldnames=rows[0].keys())
+            w.writeheader(); w.writerows(rows)
+        s = np.array([r["sim3_scale"] for r in rows])
+        br = np.array([r["bbox_ratio"] for r in rows])
+        print("\n================ 汇总 ================")
+        print(f"episodes: {len(rows)}")
+        print(f"Sim3 尺度因子 s  : mean={s.mean():.3f}  median={np.median(s):.3f}  std={s.std():.3f}")
+        print(f"  (s>1 → ORB偏小/基线偏小;  s<1 → ORB偏大;  s≈1 → 一致)")
+        print(f"bbox 对角线比     : mean={br.mean():.3f}  median={np.median(br):.3f}")
+        print(f"CSV: {csvp}")
+
+
+if __name__ == "__main__":
+    main()

--- a/schemes_compare/run_orb_scheme.py
+++ b/schemes_compare/run_orb_scheme.py
@@ -4,13 +4,26 @@
 轨迹存到该方案子文件夹。已有 CameraTrajectory.txt 则跳过。
 用法: python3 run_orb_scheme.py <schemes_dir> <scheme_name>   例: ... 144418-schemes maskgripper
 """
-import sys, subprocess
+import argparse, os, sys, subprocess
 from pathlib import Path
 
-ORB = Path.home() / "code" / "ORB_SLAM3"
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("schemes_dir", type=Path)
+parser.add_argument("scheme_name")
+parser.add_argument("--orbslam-dir", type=Path,
+                    default=Path(os.environ.get("ORB_SLAM3_DIR", Path.home() / "code" / "ORB_SLAM3")))
+args = parser.parse_args()
+ORB = args.orbslam_dir.resolve()
 STEREO = ORB / "Examples" / "Stereo" / "stereo_kitti"
 VOCAB = ORB / "Vocabulary" / "ORBvoc.txt"
-schemes = Path(sys.argv[1]); scheme = sys.argv[2]
+if not STEREO.is_file():
+    parser.error(f"stereo_kitti not found: {STEREO}")
+if not os.access(STEREO, os.X_OK):
+    parser.error(f"stereo_kitti is not executable: {STEREO}")
+if not VOCAB.is_file():
+    parser.error(f"ORB vocabulary not found: {VOCAB}")
+schemes = args.schemes_dir.resolve()
+scheme = args.scheme_name
 
 eps = sorted(d for d in schemes.iterdir() if d.is_dir() and d.name.startswith("episode_"))
 ok = skip = fail = 0
@@ -22,9 +35,13 @@ for i, ep in enumerate(eps, 1):
     if traj.exists():
         print(f"[{i}/{len(eps)}] {ep.name}/{scheme}: 已有轨迹，跳过", flush=True); skip += 1; continue
     cfg = sd / "orb_slam_realsense_d405.yaml"
+    if not cfg.is_file():
+        print(f"[{i}/{len(eps)}] {ep.name}/{scheme}: missing config {cfg}", flush=True)
+        fail += 1
+        continue
     r = subprocess.run([str(STEREO), str(VOCAB), str(cfg), str(sd), "false"],
                        capture_output=True, text=True)
-    if traj.exists():
+    if r.returncode == 0 and traj.exists():
         ok += 1; print(f"[{i}/{len(eps)}] {ep.name}/{scheme}: done", flush=True)
     else:
         fail += 1; print(f"[{i}/{len(eps)}] {ep.name}/{scheme}: FAIL {r.stderr[-120:]}", flush=True)

--- a/schemes_compare/run_orb_scheme.py
+++ b/schemes_compare/run_orb_scheme.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""对 schemes 结构里的某个方案子文件夹批量跑 ORB-SLAM3。
+读 <schemes>/episode_NNN/<scheme>/ 的 left_/right_(+symlink 的 yaml/times)，跑 stereo_kitti，
+轨迹存到该方案子文件夹。已有 CameraTrajectory.txt 则跳过。
+用法: python3 run_orb_scheme.py <schemes_dir> <scheme_name>   例: ... 144418-schemes maskgripper
+"""
+import sys, subprocess
+from pathlib import Path
+
+ORB = Path.home() / "code" / "ORB_SLAM3"
+STEREO = ORB / "Examples" / "Stereo" / "stereo_kitti"
+VOCAB = ORB / "Vocabulary" / "ORBvoc.txt"
+schemes = Path(sys.argv[1]); scheme = sys.argv[2]
+
+eps = sorted(d for d in schemes.iterdir() if d.is_dir() and d.name.startswith("episode_"))
+ok = skip = fail = 0
+for i, ep in enumerate(eps, 1):
+    sd = ep / scheme
+    if not sd.exists() or not (sd / "left_000000.png").exists():
+        print(f"[{i}/{len(eps)}] {ep.name}/{scheme}: 无图像，跳过", flush=True); skip += 1; continue
+    traj = sd / "CameraTrajectory.txt"
+    if traj.exists():
+        print(f"[{i}/{len(eps)}] {ep.name}/{scheme}: 已有轨迹，跳过", flush=True); skip += 1; continue
+    cfg = sd / "orb_slam_realsense_d405.yaml"
+    r = subprocess.run([str(STEREO), str(VOCAB), str(cfg), str(sd), "false"],
+                       capture_output=True, text=True)
+    if traj.exists():
+        ok += 1; print(f"[{i}/{len(eps)}] {ep.name}/{scheme}: done", flush=True)
+    else:
+        fail += 1; print(f"[{i}/{len(eps)}] {ep.name}/{scheme}: FAIL {r.stderr[-120:]}", flush=True)
+print(f"=== {scheme}: ok={ok} skip={skip} fail={fail} / {len(eps)} ===")

--- a/schemes_compare/schemes_init.py
+++ b/schemes_compare/schemes_init.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""把已有 raw + maskhalf 结果整理进干净的 schemes 结构（每个 episode 下按方案分子文件夹）。
+内参/times/彩色在 episode 根共享；每个方案子文件夹放自己的 left_/right_ 图像 + 轨迹，
+并 symlink 共享的 times.txt + yaml 进来让子目录对 ORB 自洽。
+
+用法: python schemes_init.py <src_png> <src_mask292> <dst_schemes>
+"""
+import os, shutil, sys
+from pathlib import Path
+
+src_png = Path(sys.argv[1])
+src_mask = Path(sys.argv[2])
+dst = Path(sys.argv[3])
+META = ["camera_info_color.json", "camera_info_left.json", "camera_info_right.json",
+        "orb_slam_realsense_d405.yaml", "times.txt", "timestamps.json",
+        "vive_poses.jsonl", "vive_reference.json"]
+TRAJ = ["CameraTrajectory.txt", "CameraTrajectoryTransformed.txt"]
+
+
+def populate(sub_dir: Path, img_src: Path, traj_src: Path):
+    sub_dir.mkdir(parents=True, exist_ok=True)
+    for p in img_src.iterdir():
+        if p.name.startswith("left_") or p.name.startswith("right_"):
+            shutil.copy2(p, sub_dir / p.name)
+    for t in TRAJ:
+        s = traj_src / t
+        if s.exists() and not (sub_dir / t).exists():
+            shutil.copy2(s, sub_dir / t)
+    for shared in ["times.txt", "orb_slam_realsense_d405.yaml"]:   # symlink 共享文件进子目录
+        link = sub_dir / shared
+        if not link.exists():
+            os.symlink(f"../{shared}", link)
+
+
+eps = sorted(d.name for d in src_png.iterdir() if d.is_dir() and d.name.startswith("episode_"))
+for ep in eps:
+    root = dst / ep
+    root.mkdir(parents=True, exist_ok=True)
+    for m in META:
+        s = src_png / ep / m
+        if s.exists() and not (root / m).exists():
+            shutil.copy2(s, root / m)
+    for c in (src_png / ep).glob("color_*.png"):
+        shutil.copy2(c, root / c.name)
+    populate(root / "raw", src_png / ep, src_png / ep)
+    populate(root / "maskhalf", src_mask / ep, src_mask / ep)
+print(f"done → {dst} ({len(eps)} episodes)")

--- a/schemes_compare/viz_scheme_compare.py
+++ b/schemes_compare/viz_scheme_compare.py
@@ -26,18 +26,21 @@ def render_episode(ep_dir, schemes, fps, codec, out_mp4):
         t = sd / "CameraTrajectoryTransformed.txt"
         if not t.exists():
             t = sd / "CameraTrajectory.txt"
-        p = vtv.load_poses(t)
-        if p is None or K is None:
-            return False
-        poses_per[sch] = p
-    n = min(len(color), *[len(poses_per[s]) for s in schemes])
+        poses_per[sch] = vtv.load_poses(t)
+    if K is None or not color or not any(p is not None for p in poses_per.values()):
+        return False
+    n = len(color)
     if n < 2:
         return False
     color = color[:n]
     for s in schemes:
-        poses_per[s] = poses_per[s][:n]
+        if poses_per[s] is not None:
+            poses_per[s] = poses_per[s][:n]
 
-    first = cv2.cvtColor(cv2.imread(str(color[0])), cv2.COLOR_BGR2RGB)
+    first_bgr = cv2.imread(str(color[0]))
+    if first_bgr is None:
+        raise RuntimeError(f"failed to read image: {color[0]}")
+    first = cv2.cvtColor(first_bgr, cv2.COLOR_BGR2RGB)
     H, W = first.shape[:2]
     nS = len(schemes)
     fig, axes = plt.subplots(1, nS, figsize=(4.4 * nS, 4.3), dpi=100)
@@ -46,7 +49,9 @@ def render_episode(ep_dir, schemes, fps, codec, out_mp4):
     im_objs, fut_lcs, start_dots, stop_dots = [], [], [], []
     for ax, sch in zip(axes, schemes):
         im_objs.append(ax.imshow(first)); ax.set_xticks([]); ax.set_yticks([])
-        ax.set_title(sch, fontsize=12, fontweight="bold")
+        tracked = len(poses_per[sch]) if poses_per[sch] is not None else 0
+        ax.set_title(f"{sch} ({tracked}/{len(color)} frames)",
+                     fontsize=12, fontweight="bold")
         lc = LineCollection([], linewidths=2.0, capstyle="round", zorder=4)
         ax.add_collection(lc); fut_lcs.append(lc)
         start_dots.append(ax.scatter([], [], c=["#00FF00"], s=45, zorder=6, edgecolors="black", linewidths=0.4))
@@ -62,16 +67,27 @@ def render_episode(ep_dir, schemes, fps, codec, out_mp4):
     proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
     try:
         for t in range(n):
-            img = cv2.cvtColor(cv2.imread(str(color[t])), cv2.COLOR_BGR2RGB)
+            frame = cv2.imread(str(color[t]))
+            if frame is None:
+                raise RuntimeError(f"failed to read image: {color[t]}")
+            img = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
             for i, sch in enumerate(schemes):
                 im_objs[i].set_data(img)
-                px, py = vtv.project_future(poses_per[sch], t, K)
-                pts = np.column_stack([px, py])
-                segs = np.stack([pts[:-1], pts[1:]], axis=1) if len(pts) >= 2 else np.empty((0, 2, 2))
-                fut_lcs[i].set_segments(segs); fut_lcs[i].set_colors(vtv._green_red_gradient(len(segs)))
-                start_dots[i].set_offsets([pts[0]] if len(pts) else [[np.nan, np.nan]])
-                spt = pts[-1] if len(pts) and np.isfinite(pts[-1]).all() else np.array([np.nan, np.nan])
-                stop_dots[i].set_offsets([spt])
+                if poses_per[sch] is not None and t < len(poses_per[sch]):
+                    px, py = vtv.project_future(poses_per[sch], t, K)
+                    pts = np.column_stack([px, py])
+                    segs = (np.stack([pts[:-1], pts[1:]], axis=1)
+                            if len(pts) >= 2 else np.empty((0, 2, 2)))
+                    fut_lcs[i].set_segments(segs)
+                    fut_lcs[i].set_colors(vtv._green_red_gradient(len(segs)))
+                    start_dots[i].set_offsets([pts[0]] if len(pts) else [[np.nan, np.nan]])
+                    spt = (pts[-1] if len(pts) and np.isfinite(pts[-1]).all()
+                           else np.array([np.nan, np.nan]))
+                    stop_dots[i].set_offsets([spt])
+                else:
+                    fut_lcs[i].set_segments([])
+                    start_dots[i].set_offsets([[np.nan, np.nan]])
+                    stop_dots[i].set_offsets([[np.nan, np.nan]])
             fig.canvas.draw()
             proc.stdin.write(np.asarray(fig.canvas.buffer_rgba())[..., :3].tobytes())
     except Exception:
@@ -85,7 +101,7 @@ def main():
     ap.add_argument("schemes_dir")
     ap.add_argument("--schemes", nargs="+", default=["raw", "maskhalf", "maskgripper"])
     ap.add_argument("--fps", type=int, default=20)
-    ap.add_argument("--codec", default="libx264")
+    ap.add_argument("--codec", default="libopenh264")
     args = ap.parse_args()
     sd = Path(args.schemes_dir)
     outdir = sd / "_compare"   # 放进 schemes 里，整洁

--- a/schemes_compare/viz_scheme_compare.py
+++ b/schemes_compare/viz_scheme_compare.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""多方案对比视频：每 episode 横排 N 个 RGB 面板(每方案一个)，叠该方案的投影指尖路径
+(绿→红 + 绿当前点 + 蓝终点)，动画化，按 episode 序号拼成 ALL_compare.mp4。
+需先 transform 各方案轨迹(投影按 camera_link 系)。
+用法: python3 viz_scheme_compare.py <schemes_dir> [--schemes raw maskhalf maskgripper]
+"""
+import sys, argparse, subprocess
+from pathlib import Path
+import numpy as np
+import cv2
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from matplotlib.collections import LineCollection
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "visualization"))
+import visualize_traj_video as vtv   # 复用 load_poses/load_K/project_future/TIP_KIN/_green_red_gradient
+
+
+def render_episode(ep_dir, schemes, fps, codec, out_mp4):
+    color = sorted([*ep_dir.glob("color_*.png"), *ep_dir.glob("color_*.jpg")])
+    K = vtv.load_K(ep_dir / "camera_info_color.json")
+    poses_per = {}
+    for sch in schemes:
+        sd = ep_dir / sch
+        t = sd / "CameraTrajectoryTransformed.txt"
+        if not t.exists():
+            t = sd / "CameraTrajectory.txt"
+        p = vtv.load_poses(t)
+        if p is None or K is None:
+            return False
+        poses_per[sch] = p
+    n = min(len(color), *[len(poses_per[s]) for s in schemes])
+    if n < 2:
+        return False
+    color = color[:n]
+    for s in schemes:
+        poses_per[s] = poses_per[s][:n]
+
+    first = cv2.cvtColor(cv2.imread(str(color[0])), cv2.COLOR_BGR2RGB)
+    H, W = first.shape[:2]
+    nS = len(schemes)
+    fig, axes = plt.subplots(1, nS, figsize=(4.4 * nS, 4.3), dpi=100)
+    if nS == 1:
+        axes = [axes]
+    im_objs, fut_lcs, start_dots, stop_dots = [], [], [], []
+    for ax, sch in zip(axes, schemes):
+        im_objs.append(ax.imshow(first)); ax.set_xticks([]); ax.set_yticks([])
+        ax.set_title(sch, fontsize=12, fontweight="bold")
+        lc = LineCollection([], linewidths=2.0, capstyle="round", zorder=4)
+        ax.add_collection(lc); fut_lcs.append(lc)
+        start_dots.append(ax.scatter([], [], c=["#00FF00"], s=45, zorder=6, edgecolors="black", linewidths=0.4))
+        stop_dots.append(ax.scatter([], [], c=["#0000FF"], s=45, zorder=6, edgecolors="black", linewidths=0.4))
+        ax.set_xlim(0, W); ax.set_ylim(H, 0)
+    fig.subplots_adjust(left=0.01, right=0.99, top=0.86, bottom=0.02, wspace=0.05)
+    fig.suptitle(f"{ep_dir.parent.name}/{ep_dir.name}", fontsize=11, y=0.97)
+
+    cw, ch = fig.canvas.get_width_height()
+    cmd = ["ffmpeg", "-y", "-loglevel", "error", "-f", "rawvideo", "-pix_fmt", "rgb24",
+           "-s", f"{cw}x{ch}", "-r", str(fps), "-i", "-",
+           "-c:v", codec, "-pix_fmt", "yuv420p", "-r", str(fps), str(out_mp4)]
+    proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+    try:
+        for t in range(n):
+            img = cv2.cvtColor(cv2.imread(str(color[t])), cv2.COLOR_BGR2RGB)
+            for i, sch in enumerate(schemes):
+                im_objs[i].set_data(img)
+                px, py = vtv.project_future(poses_per[sch], t, K)
+                pts = np.column_stack([px, py])
+                segs = np.stack([pts[:-1], pts[1:]], axis=1) if len(pts) >= 2 else np.empty((0, 2, 2))
+                fut_lcs[i].set_segments(segs); fut_lcs[i].set_colors(vtv._green_red_gradient(len(segs)))
+                start_dots[i].set_offsets([pts[0]] if len(pts) else [[np.nan, np.nan]])
+                spt = pts[-1] if len(pts) and np.isfinite(pts[-1]).all() else np.array([np.nan, np.nan])
+                stop_dots[i].set_offsets([spt])
+            fig.canvas.draw()
+            proc.stdin.write(np.asarray(fig.canvas.buffer_rgba())[..., :3].tobytes())
+    except Exception:
+        proc.kill(); plt.close(fig); raise
+    out, err = proc.communicate(); plt.close(fig)
+    return proc.returncode == 0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("schemes_dir")
+    ap.add_argument("--schemes", nargs="+", default=["raw", "maskhalf", "maskgripper"])
+    ap.add_argument("--fps", type=int, default=20)
+    ap.add_argument("--codec", default="libx264")
+    args = ap.parse_args()
+    sd = Path(args.schemes_dir)
+    outdir = sd / "_compare"   # 放进 schemes 里，整洁
+    outdir.mkdir(exist_ok=True)
+    eps = sorted(d for d in sd.iterdir() if d.is_dir() and d.name.startswith("episode_"))
+    print(f"{sd.name}: {len(eps)} episodes × {args.schemes} → {outdir}", flush=True)
+    ok = 0
+    for i, ep in enumerate(eps, 1):
+        mp4 = outdir / f"{ep.name}.mp4"
+        if mp4.exists() and mp4.stat().st_size > 10000:
+            print(f"[{i}/{len(eps)}] {ep.name} skip", flush=True); continue
+        if render_episode(ep, args.schemes, args.fps, args.codec, mp4):
+            ok += 1; print(f"[{i}/{len(eps)}] {ep.name} ok", flush=True)
+        else:
+            print(f"[{i}/{len(eps)}] {ep.name} skip(no data)", flush=True)
+    print("concatenating...", flush=True)
+    present = [e for e in eps if (outdir / f"{e.name}.mp4").exists()]
+    lf = outdir / "_concat.txt"
+    with open(lf, "w") as f:
+        for e in present:
+            f.write(f"file '{(outdir / f'{e.name}.mp4').resolve()}'\n")
+    final = outdir / "ALL_compare.mp4"
+    subprocess.run(["ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(lf),
+                    "-c", "copy", str(final)], capture_output=True)
+    print(f"DONE: {final} ({ok} episodes)", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/visualization/visualize_traj_video.py
+++ b/visualization/visualize_traj_video.py
@@ -43,11 +43,15 @@ T_OPT_CAM = np.array([
     [0.9999999999999993, 2.6794896412773968e-08, 2.6794896468285145e-08, 0.0],
     [0.0, 0.0, 0.0, 1.0],
 ])
+# Recalibrated for this rig (2026-07-12, measured off the assembly drawing):
+# tip at +0.145 m forward, -0.030 m down in camera_link (X-fwd/Y-left/Z-up,
+# origin = optical center); gripper frame held horizontal while camera is tilted
+# 30deg down -> pitch -30deg about Y. (Point projection only uses the translation.)
 T_CAM_EE = np.array([
-    [1.601236272778861e-08, 0.5975900216637896, 0.8018018246473817, 0.12584794985962103],
-    [-0.9999999999999996, 2.679489641277399e-08, -4.963083675318166e-24, -0.00895],
-    [-2.1484196834999764e-08, -0.8018018246473815, 0.5975900216637897, 0.003582529990147798],
-    [0.0, 0.0, 0.0, 1.0],
+    [ 0.8660254, 0.0, -0.5,        0.145 ],
+    [ 0.0,       1.0,  0.0,        0.0   ],
+    [ 0.5,       0.0,  0.8660254, -0.030 ],
+    [ 0.0,       0.0,  0.0,        1.0   ],
 ])
 TIP_KIN = (T_OPT_CAM, T_CAM_EE)
 
@@ -129,7 +133,8 @@ def _out_mp4_path(ep_dir: Path, out_dir: Path | None) -> Path:
 
 
 def render_episode_video(ep_dir: Path, fps: int, codec: str, dpi: int = 100,
-                         out_dir: Path | None = None) -> bool:
+                         out_dir: Path | None = None,
+                         badge: str | None = None, badge_color: str = "#2e7d32") -> bool:
     """Render one side-by-side traj video. Returns True on success.
 
     Writes to <out_dir>/<session>_<episode>.mp4 when out_dir is set (all videos in one
@@ -165,6 +170,11 @@ def render_episode_video(ep_dir: Path, fps: int, codec: str, dpi: int = 100,
     ax_img = fig.add_subplot(1, 2, 1)
     ax3d = fig.add_subplot(1, 2, 2, projection="3d")
     fig.subplots_adjust(left=0.02, right=0.98, top=0.92, bottom=0.04, wspace=0.12)
+
+    if badge:  # optional status badge (colored block + text), top-left of the video
+        fig.text(0.005, 0.985, " " + badge + " ", color="white", fontsize=12,
+                 fontweight="bold", va="top", ha="left",
+                 bbox=dict(boxstyle="round,pad=0.35", fc=badge_color, ec="black", lw=1.0))
 
     first = cv.imread(str(images[0]))
     im_obj = ax_img.imshow(cv.cvtColor(first, cv.COLOR_BGR2RGB))
@@ -253,6 +263,8 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--max-episodes", type=int, default=0, help="Stop after N episodes (0 = no limit)")
     p.add_argument("--output", type=Path, default=None,
                    help="Write ALL videos into this folder as <session>_<episode>.mp4 (default: <episode>/traj_sidebyside.mp4)")
+    p.add_argument("--badge", default=None, help="Optional status badge text drawn top-left of the video")
+    p.add_argument("--badge-color", default="#2e7d32", help="Badge background color (default green)")
     args = p.parse_args(argv)
 
     if not args.path.exists():
@@ -277,7 +289,8 @@ def main(argv: list[str] | None = None) -> int:
         if args.max_episodes and ok >= args.max_episodes:
             break
         print(f"[{done+1}/{len(eps)}] {ep.parent.name}/{ep.name}")
-        if render_episode_video(ep, args.fps, args.codec, out_dir=args.output):
+        if render_episode_video(ep, args.fps, args.codec, out_dir=args.output,
+                                 badge=args.badge, badge_color=args.badge_color):
             ok += 1
         done += 1
     print(f"Done: {ok} video(s) rendered.")

--- a/visualization/visualize_traj_video.py
+++ b/visualization/visualize_traj_video.py
@@ -177,6 +177,10 @@ def render_episode_video(ep_dir: Path, fps: int, codec: str, dpi: int = 100,
                  bbox=dict(boxstyle="round,pad=0.35", fc=badge_color, ec="black", lw=1.0))
 
     first = cv.imread(str(images[0]))
+    if first is None:
+        print(f"  skip {ep_dir.name}: failed to read {images[0]}")
+        plt.close(fig)
+        return False
     im_obj = ax_img.imshow(cv.cvtColor(first, cv.COLOR_BGR2RGB))
     ax_img.set_xticks([]); ax_img.set_yticks([])
     title = ax_img.set_title(f"{ep_dir.parent.name}/{ep_dir.name}  f0/{n}", fontsize=10)
@@ -218,6 +222,8 @@ def render_episode_video(ep_dir: Path, fps: int, codec: str, dpi: int = 100,
     try:
         for t in range(n):
             img = cv.imread(str(images[t]))
+            if img is None:
+                raise RuntimeError(f"failed to read image: {images[t]}")
             im_obj.set_data(cv.cvtColor(img, cv.COLOR_BGR2RGB))
             title.set_text(f"{ep_dir.parent.name}/{ep_dir.name}  f{t}/{n-1}")
             # 3D panel: revealed path up to t + current head


### PR DESCRIPTION
## What
- `schemes_compare/mask_gripper_trapezoid.py`: **production pre-ORB mask** — per-eye trapezoid covering the gripper sweep region + bottom 13 rows.
- `schemes_compare/`: full raw / maskhalf / maskgripper comparison pipeline (build_session_schemes → transform → viz_scheme_compare → deviation_vs_baseline → aggregate_schemes).
- `visualization/visualize_traj_video.py`: recalibrated `T_CAM_EE` to measured rig offset (+0.145m fwd / −0.030m down, pitch −30°); added `--badge` status overlay.

## Why / conclusion
The bottom of the frame (gripper + AprilTags) poisons ORB-SLAM feature matching → trajectory collapse. Masking the gripper fixes it.

Compared 3 schemes on **287 episodes (4 Vive + 2 non-Vive sessions)**:

| scheme | result |
|---|---|
| raw (no mask) | collapses — unusable |
| maskhalf (bottom 38/97 blacked) | fixes collapse, occasional tracking loss |
| **maskgripper (gripper trapezoid only)** | **same quality + more robust** |

- Quality: where both track fully (278 eps), maskgripper vs maskhalf deviation median **0.5 mm** (equivalent).
- Robustness: maskhalf loses tracking in 9 eps, maskgripper in 5; **maskgripper recovers 4 episodes maskhalf lost**.
- → **maskgripper is the default pre-ORB mask.**

## Notes
- Trapezoid vertices are rig-measured; verified to fit both rigs. `T_CAM_EE` is recalibrated to this rig — please verify the projected green dot lands on the gripper tip on your rig.
- Data paths in scripts are examples (one machine); set `MASK_DATA` or edit `BASE`.
- Vive mocap is unreliable under occlusion — don't use as absolute ground truth without filtering occluded episodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)