### PR TITLE
Add side-by-side trajectory visualization video tool

### DIFF
--- a/visualization/visualize_traj_video.py
+++ b/visualization/visualize_traj_video.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""
+Side-by-side video: camera color frames (left) next to an animated 3D ORB-SLAM3
+trajectory (right), for manual trajectory QC. Encodes H.264 MP4 via ffmpeg
+(libopenh264, since libx264 isn't installed here).
+
+Per episode, reads CameraTrajectoryTransformed.txt (falls back to CameraTrajectory.txt)
+and the color_*.png frames, and writes <episode>/traj_sidebyside.mp4. The 3D panel
+uses a FIXED axis extent computed from the full trajectory (stable view, no rescaling)
+and progressively reveals the path with the current pose highlighted.
+
+Usage (from repo root):
+    # single episode
+    python visualization/visualize_traj_video.py .../session-png/episode_001
+    # a whole session / parent tree
+    python visualization/visualize_traj_video.py .../session-png --recursive
+    python visualization/visualize_traj_video.py .../pngs --recursive
+Options: --fps 30 --codec libopenh264 --skip-existing --max-episodes N
+"""
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+import cv2 as cv
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from matplotlib.collections import LineCollection
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 (registers 3d projection)
+import numpy as np
+
+# Fixed camera<->gripper-tip transforms for the Piper rig, hardcoded from the
+# sroi-piper piper.urdf fixed-link chain (so we don't need placo/URDF at runtime).
+# Same values examples/umi_relative_ee/visualize_predictions.py computes live via
+# placo get_T_a_b("camera_optical_link","camera_link") and get_T_a_b("camera_link","ee_link").
+#   T_OPT_CAM : pose of camera_link in camera_optical_link frame (cam-link -> optical)
+#   T_CAM_EE  : pose of ee_link (gripper tip) in camera_link frame (tip offset)
+T_OPT_CAM = np.array([
+    [2.6794896412773997e-08, -0.9999999999999996, 5.183267242978961e-17, 0.0],
+    [2.6794896357262843e-08, 7.734776252012516e-16, -0.9999999999999998, 0.0],
+    [0.9999999999999993, 2.6794896412773968e-08, 2.6794896468285145e-08, 0.0],
+    [0.0, 0.0, 0.0, 1.0],
+])
+T_CAM_EE = np.array([
+    [1.601236272778861e-08, 0.5975900216637896, 0.8018018246473817, 0.12584794985962103],
+    [-0.9999999999999996, 2.679489641277399e-08, -4.963083675318166e-24, -0.00895],
+    [-2.1484196834999764e-08, -0.8018018246473815, 0.5975900216637897, 0.003582529990147798],
+    [0.0, 0.0, 0.0, 1.0],
+])
+TIP_KIN = (T_OPT_CAM, T_CAM_EE)
+
+
+def load_poses(traj_path: Path) -> np.ndarray | None:
+    """Load a KITTI-format trajectory -> (N, 4, 4) camera-in-world poses (meters), or None."""
+    if not traj_path.exists():
+        return None
+    try:
+        raw = np.loadtxt(traj_path, comments="#")
+    except Exception:
+        return None
+    if raw.size == 0:
+        return None
+    if raw.ndim == 1:
+        raw = raw.reshape(1, -1)
+    if raw.shape[1] == 13:
+        raw = raw[:, 1:]
+    if raw.shape[1] < 12:
+        return None
+    poses34 = raw[:, :12].reshape(-1, 3, 4)
+    bottom = np.tile(np.array([0.0, 0.0, 0.0, 1.0]), (len(poses34), 1, 1))
+    return np.concatenate([poses34, bottom], axis=1)  # (N, 4, 4)
+
+
+def load_K(cam_info_path: Path) -> np.ndarray | None:
+    """Load the color camera intrinsics (3x3) from camera_info_color.json, or None."""
+    import json
+    if not cam_info_path.exists():
+        return None
+    try:
+        K = np.array(json.load(cam_info_path.open())["K"], dtype=float).reshape(3, 3)
+    except Exception:
+        return None
+    return K
+
+
+def project_future(poses: np.ndarray, t: int, K: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Project the gripper-tip path from the CURRENT frame t through the end into
+    frame t's image (includes the current tip so the trail starts "now").
+
+    Mirrors visualize_predictions.py: poses are treated as camera_link poses; the
+    relative motion T_rel = inv(poses[t]) @ poses[k] is composed with the hardcoded
+    camera->tip offset (TIP_KIN), giving the gripper tip in the current optical frame:
+        p_tip = (T_opt_cam @ T_rel @ T_cam_ee)[:3, 3]
+    then projected with the (optical) color intrinsics K. Returns (px, py) for k=t..end
+    in pixel coords (NaN where behind the camera).
+    """
+    T_t_inv = np.linalg.inv(poses[t])
+    T_opt_cam, T_cam_ee = TIP_KIN
+    pts = np.empty((len(poses) - t, 3))
+    for i, k in enumerate(range(t, len(poses))):
+        T_rel = T_t_inv @ poses[k]
+        pts[i] = (T_opt_cam @ T_rel @ T_cam_ee)[:3, 3]
+    ox, oy, oz = pts[:, 0], pts[:, 1], pts[:, 2]
+    fx, fy, cx, cy = K[0, 0], K[1, 1], K[0, 2], K[1, 2]
+    px = fx * ox / oz + cx
+    py = fy * oy / oz + cy
+    behind = oz <= 1e-3
+    px = np.where(behind, np.nan, px)
+    py = np.where(behind, np.nan, py)
+    return px, py
+
+
+def _green_red_gradient(n_seg: int) -> list[tuple[float, float, float]]:
+    """vispred-style per-segment colors: green (start) -> red (end)."""
+    if n_seg <= 1:
+        return [(0.0, 1.0, 0.0)]
+    return [((i / (n_seg - 1)), (1.0 - i / (n_seg - 1)), 0.0) for i in range(n_seg)]
+
+
+def _out_mp4_path(ep_dir: Path, out_dir: Path | None) -> Path:
+    """Output mp4 path for an episode: <out_dir>/<session>_<episode>.mp4 if out_dir
+    is given (all videos in one folder), else <episode>/traj_sidebyside.mp4."""
+    if out_dir is not None:
+        stem = ep_dir.parent.name.replace("-png", "") + "_" + ep_dir.name
+        return out_dir / f"{stem}.mp4"
+    return ep_dir / "traj_sidebyside.mp4"
+
+
+def render_episode_video(ep_dir: Path, fps: int, codec: str, dpi: int = 100,
+                         out_dir: Path | None = None) -> bool:
+    """Render one side-by-side traj video. Returns True on success.
+
+    Writes to <out_dir>/<session>_<episode>.mp4 when out_dir is set (all videos in one
+    folder), otherwise <episode>/traj_sidebyside.mp4 next to the data.
+    """
+    poses = load_poses(ep_dir / "CameraTrajectoryTransformed.txt")
+    if poses is None:
+        poses = load_poses(ep_dir / "CameraTrajectory.txt")
+    if poses is None:
+        print(f"  skip {ep_dir.name}: no trajectory")
+        return False
+    images = sorted([*ep_dir.glob("color_*.png"), *ep_dir.glob("color_*.jpg")])
+    if not images:
+        print(f"  skip {ep_dir.name}: no color frames")
+        return False
+    K = load_K(ep_dir / "camera_info_color.json")
+    n = min(len(poses), len(images))
+    if n < 2:
+        print(f"  skip {ep_dir.name}: too few frames ({n})")
+        return False
+    poses = poses[:n]
+    images = images[:n]
+    pos = poses[:, :3, 3]
+
+    # Full-traj extent (fixed axes, padded) for a stable 3D view.
+    pad = max((pos.max(axis=0) - pos.min(axis=0)).max() * 0.08, 0.02)
+    lo = pos.min(axis=0) - pad
+    hi = pos.max(axis=0) + pad
+    path_len = float(np.sum(np.linalg.norm(np.diff(pos, axis=0), axis=1)))
+
+    # Figure: left = color frame (+ projected future traj), right = 3D trajectory.
+    fig = plt.figure(figsize=(12.8, 4.8), dpi=dpi)
+    ax_img = fig.add_subplot(1, 2, 1)
+    ax3d = fig.add_subplot(1, 2, 2, projection="3d")
+    fig.subplots_adjust(left=0.02, right=0.98, top=0.92, bottom=0.04, wspace=0.12)
+
+    first = cv.imread(str(images[0]))
+    im_obj = ax_img.imshow(cv.cvtColor(first, cv.COLOR_BGR2RGB))
+    ax_img.set_xticks([]); ax_img.set_yticks([])
+    title = ax_img.set_title(f"{ep_dir.parent.name}/{ep_dir.name}  f0/{n}", fontsize=10)
+    # projected gripper-tip path overlay: green->red gradient (vispred style) +
+    # green start dot (current tip) + blue stop dot (final tip). Updated per frame.
+    fut_lc = LineCollection([], linewidths=2.2, capstyle="round", zorder=4)
+    ax_img.add_collection(fut_lc)
+    start_dot = ax_img.scatter([], [], c=["#00FF00"], s=55, zorder=6, edgecolors="black", linewidths=0.5)
+    stop_dot = ax_img.scatter([], [], c=["#0000FF"], s=55, zorder=6, edgecolors="black", linewidths=0.5)
+    ax_img.set_xlim(0, first.shape[1]); ax_img.set_ylim(first.shape[0], 0)  # image pixel coords
+
+    x, y, z = pos[:, 0], pos[:, 1], pos[:, 2]
+    line, = ax3d.plot([x[0]], [y[0]], [z[0]], color="#0072B2", lw=2.0)  # blue (CB-safe)
+    head = ax3d.scatter([x[0]], [y[0]], [z[0]], c=["#D55E00"], s=42, zorder=5)  # vermillion
+    ax3d.scatter([x[0]], [y[0]], [z[0]], c=["#009E73"], s=30, marker="o", zorder=4)  # start=green
+    ax3d.set_xlim(lo[0], hi[0]); ax3d.set_ylim(lo[1], hi[1]); ax3d.set_zlim(lo[2], hi[2])
+    ax3d.set_xlabel("X (m)", fontsize=8); ax3d.set_ylabel("Y (m)", fontsize=8); ax3d.set_zlabel("Z (m)", fontsize=8)
+    ax3d.tick_params(labelsize=7)
+    try:
+        ax3d.set_box_aspect((hi[0]-lo[0], hi[1]-lo[1], max(hi[2]-lo[2], 1e-3)))
+    except Exception:
+        pass
+    ax3d.view_init(elev=22, azim=-60)
+    ax3d.set_title(f"3D trajectory  ({path_len*100:.1f} cm)", fontsize=10)
+
+    canvas_w, canvas_h = fig.canvas.get_width_height()
+    out_path = _out_mp4_path(ep_dir, out_dir)
+    if out_dir is not None:
+        out_dir.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        "ffmpeg", "-y", "-loglevel", "error",
+        "-f", "rawvideo", "-pix_fmt", "rgb24",
+        "-s", f"{canvas_w}x{canvas_h}", "-r", str(fps), "-i", "-",
+        "-c:v", codec, "-pix_fmt", "yuv420p", "-r", str(fps),
+        str(out_path),
+    ]
+    proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+
+    try:
+        for t in range(n):
+            img = cv.imread(str(images[t]))
+            im_obj.set_data(cv.cvtColor(img, cv.COLOR_BGR2RGB))
+            title.set_text(f"{ep_dir.parent.name}/{ep_dir.name}  f{t}/{n-1}")
+            # 3D panel: revealed path up to t + current head
+            line.set_data(x[:t + 1], y[:t + 1])
+            line.set_3d_properties(z[:t + 1])
+            head._offsets3d = ([x[t]], [y[t]], [z[t]])
+            # RGB panel: project gripper-tip path (current..end) into the frame,
+            # drawn as a green->red gradient with green start (current tip) + blue stop.
+            if K is not None:
+                px, py = project_future(poses, t, K)
+                pts = np.column_stack([px, py])
+                segs = np.stack([pts[:-1], pts[1:]], axis=1) if len(pts) >= 2 else np.empty((0, 2, 2))
+                fut_lc.set_segments(segs)
+                fut_lc.set_colors(_green_red_gradient(len(segs)))
+                start_dot.set_offsets([pts[0]] if len(pts) else [[np.nan, np.nan]])
+                stop_pt = pts[-1] if len(pts) and np.isfinite(pts[-1]).all() else np.array([np.nan, np.nan])
+                stop_dot.set_offsets([stop_pt])
+            else:
+                fut_lc.set_segments([])
+                start_dot.set_offsets([[np.nan, np.nan]]); stop_dot.set_offsets([[np.nan, np.nan]])
+            fig.canvas.draw()
+            rgb = np.asarray(fig.canvas.buffer_rgba())[..., :3]  # (H, W, 3)
+            proc.stdin.write(rgb.tobytes())
+    except Exception:
+        proc.kill()
+        plt.close(fig)
+        raise
+    out, err = proc.communicate()  # closes stdin + waits
+    plt.close(fig)
+    if proc.returncode != 0:
+        print(f"  ffmpeg error for {ep_dir.name}: {err.decode()[:300]}")
+        return False
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("path", type=Path, help="Episode dir, or session/parent with --recursive")
+    p.add_argument("--recursive", action="store_true", help="Process all episode_* dirs under path")
+    p.add_argument("--fps", type=int, default=30)
+    p.add_argument("--codec", default="libopenh264", help="ffmpeg video codec (default libopenh264 = H.264)")
+    p.add_argument("--skip-existing", action="store_true")
+    p.add_argument("--max-episodes", type=int, default=0, help="Stop after N episodes (0 = no limit)")
+    p.add_argument("--output", type=Path, default=None,
+                   help="Write ALL videos into this folder as <session>_<episode>.mp4 (default: <episode>/traj_sidebyside.mp4)")
+    args = p.parse_args(argv)
+
+    if not args.path.exists():
+        print(f"not found: {args.path}", file=sys.stderr); return 1
+
+    if args.recursive:
+        eps = sorted([d for d in args.path.rglob("episode_*") if d.is_dir()])
+    elif (args.path / "CameraTrajectoryTransformed.txt").exists() or (args.path / "CameraTrajectory.txt").exists():
+        eps = [args.path]  # single episode dir
+    else:
+        eps = sorted([d for d in args.path.glob("episode_*") if d.is_dir()])  # session dir
+
+    if args.output is not None:
+        args.output.mkdir(parents=True, exist_ok=True)
+        print(f"Output folder: {args.output} ({len(eps)} episodes)")
+
+    done = 0; ok = 0
+    for ep in eps:
+        out = _out_mp4_path(ep, args.output)
+        if args.skip_existing and out.exists():
+            continue
+        if args.max_episodes and ok >= args.max_episodes:
+            break
+        print(f"[{done+1}/{len(eps)}] {ep.parent.name}/{ep.name}")
+        if render_episode_video(ep, args.fps, args.codec, out_dir=args.output):
+            ok += 1
+        done += 1
+    print(f"Done: {ok} video(s) rendered.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
visualization/visualize_traj_video.py: per-episode H.264 (libopenh264) MP4 with two panels side by side for manual ORB-SLAM3 trajectory QC:
- LEFT: the color camera frame with the projected future GRIPPER-TIP path overlaid, drawn as a green->red gradient (mirroring examples/umi_relative_ee/visualize_predictions.py) with a green start dot (current tip) and a blue stop dot (final tip). The tip is offset from the camera via a hardcoded camera<->ee_link transform (T_OPT_CAM, T_CAM_EE) derived from the sroi-piper piper.urdf, so no placo/URDF runtime dep.
- RIGHT: the 3D trajectory (CameraTrajectoryTransformed.txt) progressively revealed, with start/current markers on a fixed-extent axis.

Writes <episode>/traj_sidebyside.mp4 by default, or all videos to one folder as <session>_<episode>.mp4 via --output. Supports --recursive, --skip-existing, --max-episodes, --fps, --codec.