### PR TITLE
Integrate gripper mask into ORB-SLAM and enhance comparison tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,13 @@ python decode_videos.py <input> --recursive -o /path/to/output
 
 # Run ORB-SLAM3 on every episode
 # Host install (e.g. ~/code/ORB_SLAM3) — pass the install dir explicitly:
-batches/orbslam_batch_local.sh /path/to/session-png ~/code/ORB_SLAM3 [skip_existing=true] [visualization=false]
+batches/orbslam_batch_local.sh /path/to/session-png ~/code/ORB_SLAM3 [skip_existing=true] [visualization=false] [--mask-config PATH]
 # Inside the ORB_SLAM3 Docker container (hardcoded /ORB_SLAM3 paths):
-batches/orbslam_batch_d405.sh /path/to/session-png [skip_existing=true] [visualization=false]
+batches/orbslam_batch_d405.sh /path/to/session-png [skip_existing=true] [visualization=false] [--mask-config PATH]
+
+# Render trajectory projection using the matching camera/gripper extrinsics
+python visualization/visualize_traj_video.py /path/to/session-png --recursive \
+    --extrinsics-config configs/camera_gripper_extrinsics_sroi_v2_d405.json
 
 # Transform ORB-SLAM camera trajectory into X-forward initial-camera frame
 python transform_trajectory.py --recursive /path/to/session-png
@@ -84,6 +88,9 @@ All steps agree on this on-disk shape and use the suffixes to know which step a 
 ### Recording produces everything downstream needs
 `record_realsense.py` is more than a recorder: it also writes the ORB-SLAM YAML for the recorded camera (D405 uses fixed calibration, D435i uses live calibration), so the ORB-SLAM step is fully driven by recording output. Switching cameras (D405 vs D435i) requires the matching `configs/sroi_v*.json` for gripper estimation and a different `batches/orbslam_batch_*.sh` — don't mix them.
 
+### Rig-specific mask and projection configs
+Gripper masking is opt-in in the standard ORB batch scripts. Passing `--mask-config` creates temporary masked stereo frames, runs ORB-SLAM3 on them, copies `CameraTrajectory.txt` back to the original episode, and removes the temporary input; source images are not changed. Omitting the option preserves the original unmasked path. Projection visualization separately loads camera-to-gripper-tip transforms through `--extrinsics-config`. The supplied SROI v2 D405 files are `configs/gripper_mask_sroi_v2_d405.json` and `configs/camera_gripper_extrinsics_sroi_v2_d405.json`; use matching files for another physical rig. Schema and validation details are in `doc/rig_configs.md`.
+
 ### Encoding modes trade off disk vs memory
 `record_realsense.py` defaults to PNG. `--encode-video` writes MP4 (smallest, requires `av`). Three encoding paths:
 - **PNG/JPEG to disk** (default): write frames as you go.
@@ -125,7 +132,6 @@ The LeRobot converter auto-adds its local `lerobot/` package to `sys.path` when 
 
 ## Repo quirks
 
-- `AGENTS.md` is in `.gitignore` — it will not be committed. Treat it as a local-only aid.
 - `batches/orbslam_batch_d405.sh` and `orbslam_batch.sh` assume the ORB_SLAM3 Docker container (`/ORB_SLAM3` paths); `orbslam_batch_local.sh` takes the install dir as `$2` and runs on the host.
 - `extract_rgbd/` and `notebooks/` contain older/experimental variants and Jupyter scratch — prefer the top-level scripts for new work.
 - The host ORB_SLAM3 install lives at `/home/zfei/code/ORB_SLAM3`; `stereo_kitti` is invoked directly when using the local batch.

--- a/README.md
+++ b/README.md
@@ -50,9 +50,28 @@ cd ~/code/ORB_SLAM3
     ~/Desktop/435/20260520_143052-png/episode_001/orb_slam_realsense_d405.yaml \
     ~/Desktop/435/20260520_143052-png/episode_001 false
 
-# Batch all episodes
+# Batch all episodes (unchanged behavior: no mask)
 ./batches/orbslam_batch_d405.sh ~/Desktop/435/20260520_143052-png
+
+# Opt in to a rig-specific gripper mask before ORB-SLAM
+./batches/orbslam_batch_d405.sh ~/Desktop/435/20260520_143052-png true false \
+    --mask-config /codes/sroi_rosbag_utilities/configs/gripper_mask_sroi_v2_d405.json
+
+# Host install with the same optional mask
+batches/orbslam_batch_local.sh ~/Desktop/435/20260520_143052-png ~/code/ORB_SLAM3 \
+    true false --mask-config configs/gripper_mask_sroi_v2_d405.json
 ```
+
+When `--mask-config` is provided, the batch creates a temporary masked copy of each
+episode's stereo frames, runs ORB-SLAM3 on that copy, saves `CameraTrajectory.txt` back
+to the original episode, and removes the temporary images. Original recordings are
+never modified. Omitting the option preserves the previous unmasked behavior.
+
+Mask JSON files define the expected image size, per-eye polygons, and an optional
+full-width `black_below_row`. Use a different config for a different gripper/camera
+assembly; `configs/gripper_mask_sroi_v2_d405.json` contains the current 640x480 D405
+geometry. See [`doc/rig_configs.md`](doc/rig_configs.md) for the schema,
+validation rules, temporary-file behavior, and instructions for adding another rig.
 
 ### Step 4: Transform Trajectory
 
@@ -90,6 +109,20 @@ sanity-check the range before trusting the normalized `gripper_distances.txt` fi
 Add `--median_filter 3` (must be odd) to smooth single-frame AprilTag detection noise
 in the raw distances before the min/max is computed and episodes are normalized.
 Default is `1` (no filtering).
+
+### Optional: Trajectory projection video
+
+The camera-to-gripper-tip transforms used by the projection overlay are loaded from a
+standalone JSON config:
+
+```bash
+python visualization/visualize_traj_video.py /path/to/session-png --recursive \
+    --extrinsics-config configs/camera_gripper_extrinsics_sroi_v2_d405.json
+```
+
+Use a different extrinsics config for a different camera/gripper assembly.
+The matrix convention and calibration checks are documented in
+[`doc/rig_configs.md`](doc/rig_configs.md).
 
 ### Step 6: QC and Convert to LeRobot Dataset
 

--- a/apply_gripper_mask.py
+++ b/apply_gripper_mask.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Create a masked stereo ORB-SLAM input directory from one episode.
+
+The source episode is never modified. Mask geometry and expected image dimensions come
+from a JSON config. Output stereo frames are always PNG so stereo_kitti can load them.
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+
+def _validate_mask_config(config: dict, config_path: Path) -> dict:
+    if config.get("schema_version") != 1:
+        raise ValueError(f"{config_path}: schema_version must be 1")
+
+    size = config.get("image_size")
+    if not isinstance(size, dict):
+        raise ValueError(f"{config_path}: image_size must be an object")
+    width = size.get("width")
+    height = size.get("height")
+    if not isinstance(width, int) or width <= 0 or not isinstance(height, int) or height <= 0:
+        raise ValueError(f"{config_path}: image_size width/height must be positive integers")
+
+    streams = config.get("streams")
+    if not isinstance(streams, dict):
+        raise ValueError(f"{config_path}: streams must be an object")
+
+    normalized = {"image_size": (width, height), "streams": {}}
+    for stream in ("left", "right"):
+        spec = streams.get(stream)
+        if not isinstance(spec, dict):
+            raise ValueError(f"{config_path}: streams.{stream} must be an object")
+        polygons = spec.get("polygons", [])
+        if not isinstance(polygons, list):
+            raise ValueError(f"{config_path}: streams.{stream}.polygons must be a list")
+
+        normalized_polygons = []
+        for polygon_index, polygon in enumerate(polygons):
+            if not isinstance(polygon, list) or len(polygon) < 3:
+                raise ValueError(
+                    f"{config_path}: streams.{stream}.polygons[{polygon_index}] "
+                    "must contain at least three points"
+                )
+            points = np.asarray(polygon, dtype=np.float64)
+            if points.shape != (len(polygon), 2) or not np.isfinite(points).all():
+                raise ValueError(
+                    f"{config_path}: streams.{stream}.polygons[{polygon_index}] "
+                    "must contain finite [x, y] points"
+                )
+            if not np.equal(points, np.floor(points)).all():
+                raise ValueError(f"{config_path}: mask polygon coordinates must be integers")
+            points = points.astype(np.int32)
+            if (
+                (points[:, 0] < 0).any()
+                or (points[:, 0] >= width).any()
+                or (points[:, 1] < 0).any()
+                or (points[:, 1] >= height).any()
+            ):
+                raise ValueError(
+                    f"{config_path}: streams.{stream}.polygons[{polygon_index}] "
+                    f"falls outside {width}x{height}"
+                )
+            normalized_polygons.append(points)
+
+        black_below = spec.get("black_below_row")
+        if black_below is not None and (
+            not isinstance(black_below, int) or not 0 <= black_below <= height
+        ):
+            raise ValueError(
+                f"{config_path}: streams.{stream}.black_below_row must be null "
+                f"or an integer in [0, {height}]"
+            )
+        if not normalized_polygons and black_below is None:
+            raise ValueError(f"{config_path}: streams.{stream} defines no mask")
+
+        normalized["streams"][stream] = {
+            "polygons": normalized_polygons,
+            "black_below_row": black_below,
+        }
+    return normalized
+
+
+def load_mask_config(config_path: Path | str) -> dict:
+    config_path = Path(config_path).resolve()
+    try:
+        with config_path.open() as config_file:
+            config = json.load(config_file)
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"failed to load mask config {config_path}: {error}") from error
+    if not isinstance(config, dict):
+        raise ValueError(f"{config_path}: top-level JSON value must be an object")
+    return _validate_mask_config(config, config_path)
+
+
+def apply_mask(image: np.ndarray, stream_config: dict, image_size: tuple[int, int],
+               source_path: Path | None = None) -> np.ndarray:
+    if image is None:
+        label = f": {source_path}" if source_path else ""
+        raise ValueError(f"cannot mask an unreadable image{label}")
+    width, height = image_size
+    if image.shape[:2] != (height, width):
+        label = f" ({source_path})" if source_path else ""
+        raise ValueError(
+            f"expected {width}x{height}, got {image.shape[1]}x{image.shape[0]}{label}"
+        )
+
+    masked = image.copy()
+    for polygon in stream_config["polygons"]:
+        cv2.fillPoly(masked, [polygon], 0)
+    black_below = stream_config["black_below_row"]
+    if black_below is not None:
+        masked[black_below:] = 0
+    return masked
+
+
+def _find_stream_images(episode_dir: Path, stream: str) -> list[Path]:
+    images = []
+    for suffix in ("png", "jpg", "jpeg"):
+        images.extend(episode_dir.glob(f"{stream}_*.{suffix}"))
+    images = sorted(images, key=lambda path: path.stem)
+    stems = [path.stem for path in images]
+    if len(stems) != len(set(stems)):
+        raise ValueError(f"{episode_dir}: duplicate {stream} frame stems across image formats")
+    return images
+
+
+def _link_metadata(source_dir: Path, output_dir: Path) -> None:
+    metadata = [source_dir / "times.txt", *sorted(source_dir.glob("*.yaml"))]
+    for source in metadata:
+        if not source.exists():
+            continue
+        destination = output_dir / source.name
+        if destination.exists() or destination.is_symlink():
+            destination.unlink()
+        destination.symlink_to(source.resolve())
+
+
+def prepare_masked_episode(
+    source_dir: Path | str,
+    output_dir: Path | str,
+    config: dict,
+) -> tuple[int, int]:
+    source_dir = Path(source_dir).resolve()
+    output_dir = Path(output_dir).resolve()
+    if not source_dir.is_dir():
+        raise ValueError(f"episode directory does not exist: {source_dir}")
+    if source_dir == output_dir:
+        raise ValueError("masked output directory must differ from the source episode")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for pattern in ("left_*.png", "right_*.png"):
+        for stale in output_dir.glob(pattern):
+            stale.unlink()
+    for stale_name in ("CameraTrajectory.txt", "CameraTrajectoryTransformed.txt"):
+        stale = output_dir / stale_name
+        if stale.exists():
+            stale.unlink()
+    _link_metadata(source_dir, output_dir)
+
+    counts = {}
+    for stream in ("left", "right"):
+        images = _find_stream_images(source_dir, stream)
+        if not images:
+            raise ValueError(f"{source_dir}: no {stream}_* stereo images found")
+        for frame_index, source in enumerate(images):
+            expected_stem = f"{stream}_{frame_index:06d}"
+            if source.stem != expected_stem:
+                raise ValueError(
+                    f"{source_dir}: expected {expected_stem}, found {source.stem}"
+                )
+            image = cv2.imread(str(source), cv2.IMREAD_UNCHANGED)
+            masked = apply_mask(
+                image,
+                config["streams"][stream],
+                config["image_size"],
+                source,
+            )
+            destination = output_dir / f"{source.stem}.png"
+            if not cv2.imwrite(str(destination), masked):
+                raise OSError(f"failed to write masked image: {destination}")
+        counts[stream] = len(images)
+
+    if counts["left"] != counts["right"]:
+        raise ValueError(
+            f"{source_dir}: stereo frame count mismatch "
+            f"({counts['left']} left, {counts['right']} right)"
+        )
+
+    times_path = source_dir / "times.txt"
+    if not times_path.is_file():
+        raise ValueError(f"{source_dir}: times.txt is required by stereo_kitti")
+    timestamp_count = sum(1 for line in times_path.read_text().splitlines() if line.strip())
+    if timestamp_count != counts["left"]:
+        raise ValueError(
+            f"{source_dir}: times.txt has {timestamp_count} timestamps for "
+            f"{counts['left']} stereo frames"
+        )
+    return counts["left"], counts["right"]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("episode_dir", type=Path)
+    parser.add_argument("output_dir", type=Path)
+    parser.add_argument("--config", required=True, type=Path, help="Gripper mask JSON config")
+    args = parser.parse_args()
+
+    try:
+        config = load_mask_config(args.config)
+        left_count, right_count = prepare_masked_episode(
+            args.episode_dir,
+            args.output_dir,
+            config,
+        )
+    except (OSError, ValueError) as error:
+        parser.error(str(error))
+    print(
+        f"Prepared masked ORB input: {left_count} left / {right_count} right frames "
+        f"at {args.output_dir.resolve()}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/batches/orbslam_batch.sh
+++ b/batches/orbslam_batch.sh
@@ -8,6 +8,7 @@
 #   $1 - input_directory: Path to directory containing segment folders
 #   $2 - skip_existing: "true" to skip folders with CameraTrajectory.txt (default: false)
 #   $3 - visualization: "true" to enable GUI (default: false)
+#   $4/$5 - optional: --mask-config PATH
 
 ORB_SLAM_DIR="/ORB_SLAM3"
 STEREO_KITTI="$ORB_SLAM_DIR/Examples/Stereo/stereo_kitti"
@@ -18,11 +19,27 @@ CAMERA_CONFIG="Examples/Stereo/RealSense_D435i.yaml"
 INPUT_DIR="${1:-}"
 SKIP_EXIST="${2:-false}"
 VISUALIZATION="${3:-false}"
+MASK_CONFIG=""
+if [ -n "${4:-}" ]; then
+    if [ "$4" != "--mask-config" ] || [ -z "${5:-}" ] || [ -n "${6:-}" ]; then
+        echo "Error: optional mask syntax is --mask-config PATH" >&2
+        exit 1
+    fi
+    MASK_CONFIG="$5"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/orbslam_mask_helpers.sh"
 
 if [ -z "$INPUT_DIR" ]; then
-    echo "Usage: $0 <input_directory> [skip_existing] [visualization]"
+    echo "Usage: $0 <input_directory> [skip_existing] [visualization] [--mask-config PATH]"
     echo "  skip_existing: \"true\" to skip folders with CameraTrajectory.txt"
     echo "  visualization: \"true\" to enable GUI"
+    echo "  --mask-config: optional gripper-mask JSON; omitted means no masking"
+    exit 1
+fi
+
+if ! sroi_configure_mask "$MASK_CONFIG"; then
     exit 1
 fi
 
@@ -35,6 +52,7 @@ echo "============================================"
 echo "Input directory: $INPUT_DIR"
 echo "Skip existing: $SKIP_EXIST"
 echo "Visualization: $VISUALIZATION"
+echo "Mask config: ${SROI_MASK_CONFIG:-none}"
 echo ""
 
 # Find segment folders
@@ -84,23 +102,29 @@ for folder in "${SEGMENT_FOLDERS[@]}"; do
         CONFIG_TO_USE="$CAMERA_CONFIG"
     fi
 
+    if ! sroi_prepare_orb_input "$folder"; then
+        echo "  Error: failed to prepare masked ORB input"
+        ERROR_COUNT=$((ERROR_COUNT + 1))
+        continue
+    fi
+
     # Run ORB_SLAM3
     cd "$ORB_SLAM_DIR"
 
     if [ "$VISUALIZATION" = "true" ]; then
-        "$STEREO_KITTI" "$VOCAB" "$CONFIG_TO_USE" "$folder" true
+        "$STEREO_KITTI" "$VOCAB" "$CONFIG_TO_USE" "$SROI_ORB_INPUT_DIR" true
     else
-        "$STEREO_KITTI" "$VOCAB" "$CONFIG_TO_USE" "$folder" false
+        "$STEREO_KITTI" "$VOCAB" "$CONFIG_TO_USE" "$SROI_ORB_INPUT_DIR" false
     fi
 
-    # Check if trajectory was created
-    if [ -f "$OUTPUT_FILE" ]; then
+    if sroi_collect_trajectory "$folder"; then
         echo "  Done: CameraTrajectory.txt saved"
         SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
     else
         echo "  Error: CameraTrajectory.txt not generated"
         ERROR_COUNT=$((ERROR_COUNT + 1))
     fi
+    sroi_cleanup_mask_input
 done
 
 # Summary

--- a/batches/orbslam_batch_d405.sh
+++ b/batches/orbslam_batch_d405.sh
@@ -9,6 +9,7 @@
 #   $1 - session_dir: Path to session directory containing episode_* folders
 #   $2 - skip_existing: "true" to skip episodes with CameraTrajectory.txt (default: true)
 #   $3 - visualization: "true" to enable GUI (default: false)
+#   $4/$5 - optional: --mask-config PATH
 
 ORB_SLAM_DIR="/ORB_SLAM3"
 STEREO_KITTI="$ORB_SLAM_DIR/Examples/Stereo/stereo_kitti"
@@ -18,12 +19,28 @@ VOCAB="$ORB_SLAM_DIR/Vocabulary/ORBvoc.txt"
 SESSION_DIR="${1:-}"
 SKIP_EXIST="${2:-true}"
 VISUALIZATION="${3:-false}"
+MASK_CONFIG=""
+if [ -n "${4:-}" ]; then
+    if [ "$4" != "--mask-config" ] || [ -z "${5:-}" ] || [ -n "${6:-}" ]; then
+        echo "Error: optional mask syntax is --mask-config PATH" >&2
+        exit 1
+    fi
+    MASK_CONFIG="$5"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/orbslam_mask_helpers.sh"
 
 if [ -z "$SESSION_DIR" ]; then
-    echo "Usage: $0 <session_dir> [skip_existing] [visualization]"
+    echo "Usage: $0 <session_dir> [skip_existing] [visualization] [--mask-config PATH]"
     echo "  session_dir: path containing episode_* folders"
     echo "  skip_existing: \"true\" to skip episodes with CameraTrajectory.txt"
     echo "  visualization: \"true\" to enable GUI"
+    echo "  --mask-config: optional gripper-mask JSON; omitted means no masking"
+    exit 1
+fi
+
+if ! sroi_configure_mask "$MASK_CONFIG"; then
     exit 1
 fi
 
@@ -36,6 +53,7 @@ echo "============================================"
 echo "Session directory: $SESSION_DIR"
 echo "Skip existing: $SKIP_EXIST"
 echo "Visualization: $VISUALIZATION"
+echo "Mask config: ${SROI_MASK_CONFIG:-none}"
 echo ""
 
 # Find episode folders
@@ -86,23 +104,29 @@ for folder in "${EPISODE_FOLDERS[@]}"; do
         CONFIG_TO_USE="Examples/Stereo/RealSense_D405.yaml"
     fi
 
+    if ! sroi_prepare_orb_input "$folder"; then
+        echo "  Error: failed to prepare masked ORB input"
+        ERROR_COUNT=$((ERROR_COUNT + 1))
+        continue
+    fi
+
     # Run ORB_SLAM3
     cd "$ORB_SLAM_DIR"
 
     if [ "$VISUALIZATION" = "true" ]; then
-        "$STEREO_KITTI" "$VOCAB" "$CONFIG_TO_USE" "$folder" true
+        "$STEREO_KITTI" "$VOCAB" "$CONFIG_TO_USE" "$SROI_ORB_INPUT_DIR" true
     else
-        "$STEREO_KITTI" "$VOCAB" "$CONFIG_TO_USE" "$folder" false
+        "$STEREO_KITTI" "$VOCAB" "$CONFIG_TO_USE" "$SROI_ORB_INPUT_DIR" false
     fi
 
-    # Check if trajectory was created
-    if [ -f "$OUTPUT_FILE" ]; then
+    if sroi_collect_trajectory "$folder"; then
         echo "  Done: CameraTrajectory.txt saved"
         SUCCESS_COUNT=$((SUCCESS_COUNT + 1))
     else
         echo "  Error: CameraTrajectory.txt not generated"
         ERROR_COUNT=$((ERROR_COUNT + 1))
     fi
+    sroi_cleanup_mask_input
 done
 
 # Summary

--- a/batches/orbslam_batch_local.sh
+++ b/batches/orbslam_batch_local.sh
@@ -2,23 +2,40 @@
 # Batch process ORB_SLAM3 for episode folders
 #
 # Usage:
-#   ./orbslam_batch_portable.sh <session_dir> <orb_slam_dir> [skip_existing] [visualization]
+#   ./orbslam_batch_local.sh <session_dir> <orb_slam_dir> [skip_existing] [visualization] [--mask-config PATH]
 #
 # Examples:
-#   ./orbslam_batch_portable.sh /data/20260521_153031-png ~/code/ORB_SLAM3
-#   ./orbslam_batch_portable.sh /data/20260521_153031-png ~/code/ORB_SLAM3 true false
+#   ./orbslam_batch_local.sh /data/20260521_153031-png ~/code/ORB_SLAM3
+#   ./orbslam_batch_local.sh /data/20260521_153031-png ~/code/ORB_SLAM3 true false
+#   ./orbslam_batch_local.sh /data/20260521_153031-png ~/code/ORB_SLAM3 true false --mask-config configs/gripper_mask_sroi_v2_d405.json
 
 SESSION_DIR="${1:-}"
 ORB_SLAM_DIR="${2:-}"
 SKIP_EXIST="${3:-true}"
 VISUALIZATION="${4:-false}"
+MASK_CONFIG=""
+if [ -n "${5:-}" ]; then
+    if [ "$5" != "--mask-config" ] || [ -z "${6:-}" ] || [ -n "${7:-}" ]; then
+        echo "Error: optional mask syntax is --mask-config PATH" >&2
+        exit 1
+    fi
+    MASK_CONFIG="$6"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/orbslam_mask_helpers.sh"
 
 if [ -z "$SESSION_DIR" ] || [ -z "$ORB_SLAM_DIR" ]; then
-    echo "Usage: $0 <session_dir> <orb_slam_dir> [skip_existing] [visualization]"
+    echo "Usage: $0 <session_dir> <orb_slam_dir> [skip_existing] [visualization] [--mask-config PATH]"
     echo "  session_dir:    path containing episode_* folders"
     echo "  orb_slam_dir:   path to ORB_SLAM3 installation"
     echo "  skip_existing:  \"true\" to skip episodes with CameraTrajectory.txt (default: true)"
     echo "  visualization:  \"true\" to enable GUI (default: false)"
+    echo "  --mask-config:  optional gripper-mask JSON; omitted means no masking"
+    exit 1
+fi
+
+if ! sroi_configure_mask "$MASK_CONFIG"; then
     exit 1
 fi
 
@@ -45,6 +62,7 @@ echo "Session dir:   $SESSION_DIR"
 echo "ORB_SLAM3 dir: $ORB_SLAM_DIR"
 echo "Skip existing: $SKIP_EXIST"
 echo "Visualization: $VISUALIZATION"
+echo "Mask config:   ${SROI_MASK_CONFIG:-none}"
 echo ""
 
 EPISODE_FOLDERS=()
@@ -89,15 +107,22 @@ for folder in "${EPISODE_FOLDERS[@]}"; do
         cfg="$ORB_SLAM_DIR/Examples/Stereo/RealSense_D405.yaml"
     fi
 
-    "$STEREO_KITTI" "$VOCAB" "$cfg" "$folder" "$VISUALIZATION"
+    if ! sroi_prepare_orb_input "$folder"; then
+        echo "  Error: failed to prepare masked ORB input"
+        ERROR=$((ERROR + 1))
+        continue
+    fi
 
-    if [ -f "$outfile" ]; then
+    "$STEREO_KITTI" "$VOCAB" "$cfg" "$SROI_ORB_INPUT_DIR" "$VISUALIZATION"
+
+    if sroi_collect_trajectory "$folder"; then
         echo "  Done"
         SUCCESS=$((SUCCESS + 1))
     else
         echo "  Error: no CameraTrajectory.txt generated"
         ERROR=$((ERROR + 1))
     fi
+    sroi_cleanup_mask_input
 done
 
 echo ""

--- a/batches/orbslam_mask_helpers.sh
+++ b/batches/orbslam_mask_helpers.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Shared optional gripper-mask support for the ORB-SLAM batch scripts.
+
+SROI_MASK_HELPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SROI_MASK_TOOL="$SROI_MASK_HELPER_DIR/../apply_gripper_mask.py"
+SROI_MASK_CONFIG=""
+SROI_MASK_TEMP_DIR=""
+SROI_ORB_INPUT_DIR=""
+
+sroi_configure_mask() {
+    local config="${1:-}"
+    if [ -z "$config" ]; then
+        SROI_MASK_CONFIG=""
+        return 0
+    fi
+    if [ ! -f "$config" ]; then
+        echo "Error: mask config not found: $config" >&2
+        return 1
+    fi
+    if [ ! -f "$SROI_MASK_TOOL" ]; then
+        echo "Error: mask utility not found: $SROI_MASK_TOOL" >&2
+        return 1
+    fi
+    SROI_MASK_CONFIG="$(cd "$(dirname "$config")" && pwd)/$(basename "$config")"
+}
+
+sroi_cleanup_mask_input() {
+    if [ -n "$SROI_MASK_TEMP_DIR" ] && [ -d "$SROI_MASK_TEMP_DIR" ]; then
+        rm -rf -- "$SROI_MASK_TEMP_DIR"
+    fi
+    SROI_MASK_TEMP_DIR=""
+    SROI_ORB_INPUT_DIR=""
+}
+
+sroi_prepare_orb_input() {
+    local source_episode="$1"
+    sroi_cleanup_mask_input
+    if [ -z "$SROI_MASK_CONFIG" ]; then
+        SROI_ORB_INPUT_DIR="$source_episode"
+        return 0
+    fi
+
+    SROI_MASK_TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/sroi-orb-mask.XXXXXX")" || return 1
+    SROI_ORB_INPUT_DIR="$SROI_MASK_TEMP_DIR/episode"
+    if ! python3 "$SROI_MASK_TOOL" "$source_episode" "$SROI_ORB_INPUT_DIR" \
+        --config "$SROI_MASK_CONFIG"; then
+        sroi_cleanup_mask_input
+        return 1
+    fi
+}
+
+sroi_collect_trajectory() {
+    local destination_episode="$1"
+    if [ -z "$SROI_MASK_CONFIG" ]; then
+        [ -f "$destination_episode/CameraTrajectory.txt" ]
+        return
+    fi
+    local masked_trajectory="$SROI_ORB_INPUT_DIR/CameraTrajectory.txt"
+    if [ ! -f "$masked_trajectory" ]; then
+        return 1
+    fi
+    local destination="$destination_episode/CameraTrajectory.txt"
+    local temporary="$destination.tmp"
+    if ! cp "$masked_trajectory" "$temporary"; then
+        rm -f -- "$temporary"
+        return 1
+    fi
+    mv "$temporary" "$destination"
+}
+
+trap sroi_cleanup_mask_input EXIT
+trap 'sroi_cleanup_mask_input; exit 130' INT TERM

--- a/configs/camera_gripper_extrinsics_sroi_v2_d405.json
+++ b/configs/camera_gripper_extrinsics_sroi_v2_d405.json
@@ -1,0 +1,62 @@
+{
+  "schema_version": 1,
+  "description": "SROI v2 D405 camera-to-gripper-tip transforms for trajectory projection",
+  "transform_convention": "T_a_b maps coordinates from frame b into frame a and represents the pose of b in a",
+  "frames": {
+    "optical": "camera_optical_link",
+    "camera": "camera_link",
+    "tip": "gripper_tip"
+  },
+  "T_optical_camera": [
+    [
+      2.6794896412773997e-08,
+      -0.9999999999999996,
+      5.183267242978961e-17,
+      0.0
+    ],
+    [
+      2.6794896357262843e-08,
+      7.734776252012516e-16,
+      -0.9999999999999998,
+      0.0
+    ],
+    [
+      0.9999999999999993,
+      2.6794896412773968e-08,
+      2.6794896468285145e-08,
+      0.0
+    ],
+    [
+      0.0,
+      0.0,
+      0.0,
+      1.0
+    ]
+  ],
+  "T_camera_gripper_tip": [
+    [
+      0.8660254,
+      0.0,
+      -0.5,
+      0.145
+    ],
+    [
+      0.0,
+      1.0,
+      0.0,
+      0.0
+    ],
+    [
+      0.5,
+      0.0,
+      0.8660254,
+      -0.03
+    ],
+    [
+      0.0,
+      0.0,
+      0.0,
+      1.0
+    ]
+  ]
+}

--- a/configs/gripper_mask_sroi_v2_d405.json
+++ b/configs/gripper_mask_sroi_v2_d405.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": 1,
+  "description": "SROI v2 D405 gripper mask for 640x480 stereo IR frames",
+  "coordinate_convention": "Pixel [x, y] coordinates with origin at the top-left; x increases right and y increases down",
+  "image_size": {
+    "width": 640,
+    "height": 480
+  },
+  "streams": {
+    "left": {
+      "polygons": [
+        [
+          [
+            236,
+            292
+          ],
+          [
+            417,
+            292
+          ],
+          [
+            525,
+            467
+          ],
+          [
+            127,
+            467
+          ]
+        ]
+      ],
+      "black_below_row": 467
+    },
+    "right": {
+      "polygons": [
+        [
+          [
+            182,
+            292
+          ],
+          [
+            365,
+            292
+          ],
+          [
+            444,
+            467
+          ],
+          [
+            46,
+            467
+          ]
+        ]
+      ],
+      "black_below_row": 467
+    }
+  }
+}

--- a/doc/rig_configs.md
+++ b/doc/rig_configs.md
@@ -1,0 +1,146 @@
+# Gripper Mask and Projection Extrinsics
+
+Mask geometry and camera-to-gripper-tip projection transforms are rig-specific. Keep
+them in separate JSON files so a recording can be processed with the calibration for
+the camera/gripper assembly that produced it.
+
+The supplied SROI v2 D405 examples are:
+
+- `configs/gripper_mask_sroi_v2_d405.json`
+- `configs/camera_gripper_extrinsics_sroi_v2_d405.json`
+
+Copy and rename these files when calibrating another camera, resolution, mounting
+position, or gripper. Do not edit the D405 files to represent a different rig.
+
+## Optional gripper mask in the ORB-SLAM pipeline
+
+The standard batch commands remain unmasked unless `--mask-config` is passed. The
+option comes after the existing positional arguments:
+
+```bash
+# Host ORB-SLAM3 installation
+batches/orbslam_batch_local.sh /path/to/session-png ~/code/ORB_SLAM3 \
+    true false --mask-config configs/gripper_mask_sroi_v2_d405.json
+
+# D405 batch inside the ORB-SLAM3 container
+batches/orbslam_batch_d405.sh /path/to/session-png \
+    true false --mask-config /codes/sroi_rosbag_utilities/configs/gripper_mask_sroi_v2_d405.json
+
+# Legacy D435i segment batch inside the container
+batches/orbslam_batch.sh /path/to/segments \
+    false false --mask-config /path/to/matching-rig-mask.json
+```
+
+When masking is enabled, each episode is processed as follows:
+
+1. The stereo images are copied to a temporary directory and masked there.
+2. `times.txt` and the ORB-SLAM YAML are linked into the temporary input.
+3. ORB-SLAM3 runs against the temporary images.
+4. `CameraTrajectory.txt` is copied atomically back to the source episode.
+5. The temporary directory is removed, including after an interrupt.
+
+The recorded images are never modified. With no `--mask-config`, ORB-SLAM3 receives
+the original episode path exactly as before. When `skip_existing=true`, an episode
+that already has `CameraTrajectory.txt` is skipped before temporary masked images are
+created. Use `skip_existing=false` to regenerate an existing trajectory with a mask.
+
+The standalone equivalent for one episode is:
+
+```bash
+python apply_gripper_mask.py /path/to/episode /tmp/masked-episode \
+    --config configs/gripper_mask_sroi_v2_d405.json
+```
+
+### Mask JSON schema
+
+```json
+{
+  "schema_version": 1,
+  "image_size": {"width": 640, "height": 480},
+  "streams": {
+    "left": {
+      "polygons": [[[236, 292], [417, 292], [525, 467], [127, 467]]],
+      "black_below_row": 467
+    },
+    "right": {
+      "polygons": [[[182, 292], [365, 292], [444, 467], [46, 467]]],
+      "black_below_row": 467
+    }
+  }
+}
+```
+
+- Polygon points are integer pixel coordinates `[x, y]`, with the origin at the
+  top-left. Each polygon needs at least three in-bounds points.
+- Each eye may contain multiple polygons.
+- `black_below_row` is optional. If set to `r`, rows `r` through the bottom of the
+  image are blacked out. Use `null` to disable the horizontal cutoff.
+- Each eye must define at least one polygon or a cutoff.
+- Input images must exactly match `image_size`. Frame names must be sequential from
+  `left_000000` and `right_000000`, stereo counts must match, and the number of
+  nonempty lines in `times.txt` must equal the frame count.
+- PNG, JPEG, and JPG input frames are accepted. Temporary output is always PNG for
+  `stereo_kitti`; grayscale and color channel layouts are preserved.
+
+To calibrate a new mask, view representative left and right IR frames, choose polygons
+that cover the gripper through its full motion, and test the config on a temporary
+episode before running a full session. Stereo disparity usually means the two eyes
+need different coordinates.
+
+## Camera-to-gripper-tip projection extrinsics
+
+The trajectory video overlays the future gripper-tip path on the color frames. Load
+the transform calibration explicitly when processing a rig:
+
+```bash
+python visualization/visualize_traj_video.py /path/to/session-png --recursive \
+    --extrinsics-config configs/camera_gripper_extrinsics_sroi_v2_d405.json
+
+python schemes_compare/viz_scheme_compare.py /path/to/session-schemes \
+    --extrinsics-config configs/camera_gripper_extrinsics_sroi_v2_d405.json
+```
+
+Both commands default to the supplied SROI v2 D405 config when the option is omitted.
+That default is only appropriate for recordings made with the matching assembly.
+
+### Extrinsics JSON schema
+
+```json
+{
+  "schema_version": 1,
+  "transform_convention": "T_a_b maps coordinates from frame b into frame a",
+  "frames": {
+    "optical": "camera_optical_link",
+    "camera": "camera_link",
+    "tip": "gripper_tip"
+  },
+  "T_optical_camera": [
+    [2.6794896412773997e-08, -0.9999999999999996, 0.0, 0.0],
+    [2.6794896357262843e-08, 0.0, -0.9999999999999998, 0.0],
+    [0.9999999999999993, 2.6794896412773968e-08, 2.6794896468285145e-08, 0.0],
+    [0.0, 0.0, 0.0, 1.0]
+  ],
+  "T_camera_gripper_tip": [
+    [0.8660254, 0.0, -0.5, 0.145],
+    [0.0, 1.0, 0.0, 0.0],
+    [0.5, 0.0, 0.8660254, -0.03],
+    [0.0, 0.0, 0.0, 1.0]
+  ]
+}
+```
+
+For readability, tiny near-zero values in this example are shown as `0.0`; use the
+full measured values in the supplied config. `T_a_b` maps a point written in frame
+`b` into frame `a`:
+
+- `T_optical_camera` maps camera-link coordinates into the optical frame.
+- `T_camera_gripper_tip` gives the gripper-tip pose in the camera-link frame.
+
+Each transform must be a finite rigid 4x4 homogeneous matrix. The last row must be
+`[0, 0, 0, 1]`; the 3x3 rotation must be orthonormal with determinant +1. After
+calibrating a new file, render a short episode and verify the projected green tip path
+against the physical gripper before using it for QC.
+
+The mask config and extrinsics config are independent: the first changes the stereo
+images supplied to ORB-SLAM3, while the second is used only for trajectory projection.
+In practice, both should be versioned and named for the same physical rig.

--- a/schemes_compare/README.md
+++ b/schemes_compare/README.md
@@ -21,8 +21,11 @@
 
 跑 ORB-SLAM 前，对每个 episode 的 left_/right_ 涂黑夹爪梯形：
 ```bash
-python3 schemes_compare/mask_gripper_trapezoid.py <schemes或episode目录>
+python3 schemes_compare/mask_gripper_trapezoid.py <schemes/session/episode目录>
 ```
+输入 schemes 目录时读取 `episode_*/raw/`；输入普通 session 或单个 episode 时读取
+episode 根目录。掩膜结果统一写到 `episode_*/maskgripper/`，运行 ORB 时应把该子目录
+作为输入。
 梯形顶点（夹爪与相机刚性连接，画面里固定，只有手指开合；已跨两台设备验证通用）：
 - 左眼：[(236,292),(417,292),(525,467),(127,467)]（顶左→顶右→底右→底左）+ rows≥467 全宽黑
 - 右眼：[(182,292),(365,292),(444,467),(46,467)] + rows≥467 全宽黑
@@ -53,5 +56,6 @@ python3 schemes_compare/aggregate_schemes.py
 
 ## 注意
 - `T_CAM_EE`（相机→夹爪指尖变换，在 `visualization/visualize_traj_video.py`）是按本装置实测重标定的（指尖 +0.145m 前/−0.030m 下、pitch −30°）。换装置请核验绿点是否落夹爪中心。
-- 脚本里的数据路径是示例（默认 `/home/ss/data/1000_onesb_labpicking`），用 `MASK_DATA` 环境变量或改 `BASE` 适配你的机器。
+- 脚本里的数据路径是示例（默认 `/home/ss/data/1000_onesb_labpicking`）；可用 `MASK_DATA` 环境变量覆盖，`aggregate_schemes.py` 也接受 data-root 位置参数。
+- `run_orb_scheme.py` 默认使用 `~/code/ORB_SLAM3`；可用 `ORB_SLAM3_DIR` 或 `--orbslam-dir` 覆盖。
 - Vive 动捕在遮挡时会出错，不能盲信当真值；用前需识别并剔除被遮挡 episode。

--- a/schemes_compare/README.md
+++ b/schemes_compare/README.md
@@ -5,17 +5,22 @@ standalone tooling used for the experiment.
 
 ## Pipeline integration status
 
-**The gripper mask is not currently integrated into the canonical pipeline.** The
-normal `record_realsense.py -> decode_videos.py -> batches/orbslam_batch_*.sh`
-workflow still runs ORB-SLAM3 on the unmasked stereo images at the episode root.
-`build_session_schemes.sh` and the other scripts in this directory form a separate
-comparison workflow.
+The gripper mask is integrated into the canonical ORB batch scripts as an **opt-in**
+step. Existing commands remain unmasked. Pass a rig-specific config to enable masking:
 
-The masker writes derived images to `episode_*/maskgripper/`. The existing ORB batch
-scripts do not automatically discover that nested directory. Use
-`run_orb_scheme.py` for a schemes tree, or explicitly pass the masked directory to
-ORB-SLAM3. Making maskgripper the production default requires a separate integration
-change to the canonical ORB batch scripts and top-level pipeline documentation.
+```bash
+batches/orbslam_batch_local.sh <session> <orbslam-dir> true false \
+    --mask-config configs/gripper_mask_sroi_v2_d405.json
+
+batches/orbslam_batch_d405.sh <session> true false \
+    --mask-config configs/gripper_mask_sroi_v2_d405.json
+```
+
+The batch creates temporary masked stereo frames, runs ORB on them, copies the trajectory
+back to the original episode, and removes the temporary input. Source images are never
+modified. The mask and extrinsics schemas are documented in
+[`../doc/rig_configs.md`](../doc/rig_configs.md). The other scripts in this directory
+remain useful for multi-scheme experiments.
 
 ## Preliminary experiment findings
 
@@ -44,7 +49,8 @@ produce high-contrast moving features that violate ORB-SLAM's static-scene assum
 
 Apply the per-eye gripper mask before running ORB-SLAM:
 ```bash
-python3 schemes_compare/mask_gripper_trapezoid.py <schemes/session/episode-directory>
+python3 schemes_compare/mask_gripper_trapezoid.py <schemes/session/episode-directory> \
+    --config configs/gripper_mask_sroi_v2_d405.json
 ```
 
 For a schemes directory, the script reads `episode_*/raw/`. For a normal session or
@@ -66,8 +72,9 @@ MASK_DATA=/path/to/data bash schemes_compare/build_session_schemes.sh 20260709_X
 # 2) Transform each scheme trajectory for RGB projection
 python3 transform_trajectory.py <session>-schemes --recursive
 
-# 3) Render side-by-side comparison videos
-python3 schemes_compare/viz_scheme_compare.py <session>-schemes
+# 3) Render side-by-side comparison videos with this rig's extrinsics
+python3 schemes_compare/viz_scheme_compare.py <session>-schemes \
+    --extrinsics-config configs/camera_gripper_extrinsics_sroi_v2_d405.json
 
 # 4) Calculate completeness and deviation against maskhalf
 python3 schemes_compare/deviation_vs_baseline.py <session>-schemes
@@ -80,7 +87,7 @@ Outputs are written under `<session>-schemes/_compare/`.
 
 ## Files
 
-- `mask_gripper_trapezoid.py`: creates the maskgripper images.
+- `mask_gripper_trapezoid.py`: creates config-driven maskgripper images.
 - `mask_session.py`: creates the maskhalf comparison images.
 - `schemes_init.py`: builds the per-episode schemes layout.
 - `build_session_schemes.sh`: runs the standalone end-to-end comparison workflow.
@@ -92,8 +99,8 @@ Outputs are written under `<session>-schemes/_compare/`.
 
 ## Notes
 
-- `T_CAM_EE` in `visualization/visualize_traj_video.py` was measured for one rig.
-  Verify the projected green point on every different camera/gripper assembly.
+- Projection extrinsics are loaded from `configs/camera_gripper_extrinsics_sroi_v2_d405.json`.
+  Use a separate config and verify the projected green point for every different rig.
 - The default data root is `/home/ss/data/1000_onesb_labpicking`. Override it with
   `MASK_DATA`, or pass a data-root argument to `aggregate_schemes.py`.
 - `run_orb_scheme.py` defaults to `~/code/ORB_SLAM3`. Override it with

--- a/schemes_compare/README.md
+++ b/schemes_compare/README.md
@@ -1,61 +1,102 @@
-# schemes_compare — 遮罩方案对比 (raw / maskhalf / maskgripper)
+# Mask scheme comparison (raw / maskhalf / maskgripper)
 
-对比三种 ORB-SLAM3 前处理遮罩方案对轨迹还原的影响，并给出生产方案。
+This directory compares three pre-ORB-SLAM3 masking strategies and contains the
+standalone tooling used for the experiment.
 
-## 结论（287 集，4 个 Vive + 2 个无 Vive session 验证）
+## Pipeline integration status
 
-| 方案 | 说明 | 结果 |
+**The gripper mask is not currently integrated into the canonical pipeline.** The
+normal `record_realsense.py -> decode_videos.py -> batches/orbslam_batch_*.sh`
+workflow still runs ORB-SLAM3 on the unmasked stereo images at the episode root.
+`build_session_schemes.sh` and the other scripts in this directory form a separate
+comparison workflow.
+
+The masker writes derived images to `episode_*/maskgripper/`. The existing ORB batch
+scripts do not automatically discover that nested directory. Use
+`run_orb_scheme.py` for a schemes tree, or explicitly pass the masked directory to
+ORB-SLAM3. Making maskgripper the production default requires a separate integration
+change to the canonical ORB batch scripts and top-level pipeline documentation.
+
+## Preliminary experiment findings
+
+The original experiment covered 287 episodes from four Vive sessions and two sessions
+without Vive. It reported the following results:
+
+| Scheme | Description | Reported result |
 |---|---|---|
-| `raw` | 不遮 | 大量坍缩（轨迹缩成真实运动零头），**不可用** |
-| `maskhalf` | 底部 38/97 涂黑 (cutoff=292) | 修好坍缩，但偶有跟丢 |
-| `maskgripper` | **只遮夹爪梯形**（左右红外各一套顶点 + 底部 13 行） | **质量等价 + 跟踪更稳** |
+| `raw` | No mask | Frequent trajectory collapse |
+| `maskhalf` | Black out the bottom 38/97 of the image (cutoff 292) | Prevented collapse, with occasional tracking loss |
+| `maskgripper` | Per-eye gripper trapezoid plus the bottom 13 rows | Similar quality with fewer reported tracking losses |
 
-**数据**（以 maskhalf 为基准，纯方法间对比，不依赖 Vive）：
-- 质量：两边都跟全的 278 集，maskgripper vs maskhalf 偏差中位 **0.5mm**（亚毫米，等价）。
-- 稳健性：maskhalf 跟丢 9 集，maskgripper 跟丢 5 集；**maskgripper 救回 4 集** maskhalf 跟丢的。
-- → **生产默认用 `maskgripper`**（保留更多特征 → ORB 不易丢跟踪；额外成本仅涂黑步骤略复杂）。
+- For 278 episodes where both masked schemes tracked fully, the reported median
+  maskgripper-versus-maskhalf deviation was 0.5 mm.
+- The original summary reported 9 maskhalf losses, 5 maskgripper losses, and 4 episodes
+  recovered by maskgripper.
 
-根因：画面底部的夹爪 + AprilTag 是高对比、会动的"毒特征"，破坏 ORB-SLAM 静态场景假设。基线/标定没问题（D405 18mm 基线本就对）。
+PR #8 fixed accounting bugs that previously omitted complete maskhalf failures and
+zero-valued results. Re-run the comparison before treating the historical counts above
+as final.
 
-## 生产用法（处理新数据）
+The working hypothesis is that the gripper and AprilTags at the bottom of the frame
+produce high-contrast moving features that violate ORB-SLAM's static-scene assumption.
 
-跑 ORB-SLAM 前，对每个 episode 的 left_/right_ 涂黑夹爪梯形：
+## Manual masking usage
+
+Apply the per-eye gripper mask before running ORB-SLAM:
 ```bash
-python3 schemes_compare/mask_gripper_trapezoid.py <schemes/session/episode目录>
+python3 schemes_compare/mask_gripper_trapezoid.py <schemes/session/episode-directory>
 ```
-输入 schemes 目录时读取 `episode_*/raw/`；输入普通 session 或单个 episode 时读取
-episode 根目录。掩膜结果统一写到 `episode_*/maskgripper/`，运行 ORB 时应把该子目录
-作为输入。
-梯形顶点（夹爪与相机刚性连接，画面里固定，只有手指开合；已跨两台设备验证通用）：
-- 左眼：[(236,292),(417,292),(525,467),(127,467)]（顶左→顶右→底右→底左）+ rows≥467 全宽黑
-- 右眼：[(182,292),(365,292),(444,467),(46,467)] + rows≥467 全宽黑
-- 左眼夹爪居中→对称；右眼因立体视差左移 ~48px，故左右眼顶点不同。
 
-## 完整对比流程（复现 mg≥mh）
+For a schemes directory, the script reads `episode_*/raw/`. For a normal session or
+single episode, it reads images from the episode root. Output is always written to
+`episode_*/maskgripper/`; it does not overwrite the source images.
+
+Mask geometry for the validated 640x480 D405 rigs:
+
+- Left eye: [(236,292), (417,292), (525,467), (127,467)], plus rows 467 and below.
+- Right eye: [(182,292), (365,292), (444,467), (46,467)], plus rows 467 and below.
+- The right-eye polygon is shifted left by stereo disparity.
+
+## Full comparison workflow
 
 ```bash
-# 1) 一个 session 全量做成 schemes(raw/maskhalf/maskgripper 各跑 ORB)
+# 1) Build raw/maskhalf/maskgripper trees and run ORB for each scheme
 MASK_DATA=/path/to/data bash schemes_compare/build_session_schemes.sh 20260709_XXXXXX
-# 2) 坐标变换(投影回RGB必需)
+
+# 2) Transform each scheme trajectory for RGB projection
 python3 transform_trajectory.py <session>-schemes --recursive
-# 3) 三面板对比视频(每episode raw|maskhalf|maskgripper 并排)
+
+# 3) Render side-by-side comparison videos
 python3 schemes_compare/viz_scheme_compare.py <session>-schemes
-# 4) 完整度+偏差(以maskhalf为基准)
+
+# 4) Calculate completeness and deviation against maskhalf
 python3 schemes_compare/deviation_vs_baseline.py <session>-schemes
-# 5) 跨session总表
-python3 schemes_compare/aggregate_schemes.py
+
+# 5) Aggregate results across sessions
+python3 schemes_compare/aggregate_schemes.py /path/to/data
 ```
-输出在 `<session>-schemes/_compare/`（视频 + deviation.csv）。
 
-## 文件说明
-- `mask_gripper_trapezoid.py` — **生产掩膜**（mg）。`mask_session.py` — maskhalf（cutoff=292，对比用）。
-- `schemes_init.py` / `build_session_schemes.sh` / `run_orb_scheme.py` — schemes 结构搭建 + 批量 ORB。
-- `viz_scheme_compare.py` — 三面板对比视频（复用 `visualization/visualize_traj_video.py` 的投影）。
-- `deviation_vs_baseline.py` / `aggregate_schemes.py` — 完整度(输出帧/输入帧，丢帧=失败) + 偏差分析。
-- `orb_vs_vive.py` — ORB vs Vive 动捕真值 Sim3 对齐（Vive 准的时候用）。
+Outputs are written under `<session>-schemes/_compare/`.
 
-## 注意
-- `T_CAM_EE`（相机→夹爪指尖变换，在 `visualization/visualize_traj_video.py`）是按本装置实测重标定的（指尖 +0.145m 前/−0.030m 下、pitch −30°）。换装置请核验绿点是否落夹爪中心。
-- 脚本里的数据路径是示例（默认 `/home/ss/data/1000_onesb_labpicking`）；可用 `MASK_DATA` 环境变量覆盖，`aggregate_schemes.py` 也接受 data-root 位置参数。
-- `run_orb_scheme.py` 默认使用 `~/code/ORB_SLAM3`；可用 `ORB_SLAM3_DIR` 或 `--orbslam-dir` 覆盖。
-- Vive 动捕在遮挡时会出错，不能盲信当真值；用前需识别并剔除被遮挡 episode。
+## Files
+
+- `mask_gripper_trapezoid.py`: creates the maskgripper images.
+- `mask_session.py`: creates the maskhalf comparison images.
+- `schemes_init.py`: builds the per-episode schemes layout.
+- `build_session_schemes.sh`: runs the standalone end-to-end comparison workflow.
+- `run_orb_scheme.py`: runs ORB-SLAM3 for one scheme.
+- `viz_scheme_compare.py`: renders multi-scheme comparison videos.
+- `deviation_vs_baseline.py`: computes per-session completeness and deviation.
+- `aggregate_schemes.py`: aggregates comparison CSV files across sessions.
+- `orb_vs_vive.py`: aligns ORB trajectories with Vive motion capture.
+
+## Notes
+
+- `T_CAM_EE` in `visualization/visualize_traj_video.py` was measured for one rig.
+  Verify the projected green point on every different camera/gripper assembly.
+- The default data root is `/home/ss/data/1000_onesb_labpicking`. Override it with
+  `MASK_DATA`, or pass a data-root argument to `aggregate_schemes.py`.
+- `run_orb_scheme.py` defaults to `~/code/ORB_SLAM3`. Override it with
+  `ORB_SLAM3_DIR` or `--orbslam-dir`.
+- Vive motion capture can become unreliable under occlusion; exclude occluded episodes
+  before treating it as a reference.

--- a/schemes_compare/README.md
+++ b/schemes_compare/README.md
@@ -1,0 +1,57 @@
+# schemes_compare — 遮罩方案对比 (raw / maskhalf / maskgripper)
+
+对比三种 ORB-SLAM3 前处理遮罩方案对轨迹还原的影响，并给出生产方案。
+
+## 结论（287 集，4 个 Vive + 2 个无 Vive session 验证）
+
+| 方案 | 说明 | 结果 |
+|---|---|---|
+| `raw` | 不遮 | 大量坍缩（轨迹缩成真实运动零头），**不可用** |
+| `maskhalf` | 底部 38/97 涂黑 (cutoff=292) | 修好坍缩，但偶有跟丢 |
+| `maskgripper` | **只遮夹爪梯形**（左右红外各一套顶点 + 底部 13 行） | **质量等价 + 跟踪更稳** |
+
+**数据**（以 maskhalf 为基准，纯方法间对比，不依赖 Vive）：
+- 质量：两边都跟全的 278 集，maskgripper vs maskhalf 偏差中位 **0.5mm**（亚毫米，等价）。
+- 稳健性：maskhalf 跟丢 9 集，maskgripper 跟丢 5 集；**maskgripper 救回 4 集** maskhalf 跟丢的。
+- → **生产默认用 `maskgripper`**（保留更多特征 → ORB 不易丢跟踪；额外成本仅涂黑步骤略复杂）。
+
+根因：画面底部的夹爪 + AprilTag 是高对比、会动的"毒特征"，破坏 ORB-SLAM 静态场景假设。基线/标定没问题（D405 18mm 基线本就对）。
+
+## 生产用法（处理新数据）
+
+跑 ORB-SLAM 前，对每个 episode 的 left_/right_ 涂黑夹爪梯形：
+```bash
+python3 schemes_compare/mask_gripper_trapezoid.py <schemes或episode目录>
+```
+梯形顶点（夹爪与相机刚性连接，画面里固定，只有手指开合；已跨两台设备验证通用）：
+- 左眼：[(236,292),(417,292),(525,467),(127,467)]（顶左→顶右→底右→底左）+ rows≥467 全宽黑
+- 右眼：[(182,292),(365,292),(444,467),(46,467)] + rows≥467 全宽黑
+- 左眼夹爪居中→对称；右眼因立体视差左移 ~48px，故左右眼顶点不同。
+
+## 完整对比流程（复现 mg≥mh）
+
+```bash
+# 1) 一个 session 全量做成 schemes(raw/maskhalf/maskgripper 各跑 ORB)
+MASK_DATA=/path/to/data bash schemes_compare/build_session_schemes.sh 20260709_XXXXXX
+# 2) 坐标变换(投影回RGB必需)
+python3 transform_trajectory.py <session>-schemes --recursive
+# 3) 三面板对比视频(每episode raw|maskhalf|maskgripper 并排)
+python3 schemes_compare/viz_scheme_compare.py <session>-schemes
+# 4) 完整度+偏差(以maskhalf为基准)
+python3 schemes_compare/deviation_vs_baseline.py <session>-schemes
+# 5) 跨session总表
+python3 schemes_compare/aggregate_schemes.py
+```
+输出在 `<session>-schemes/_compare/`（视频 + deviation.csv）。
+
+## 文件说明
+- `mask_gripper_trapezoid.py` — **生产掩膜**（mg）。`mask_session.py` — maskhalf（cutoff=292，对比用）。
+- `schemes_init.py` / `build_session_schemes.sh` / `run_orb_scheme.py` — schemes 结构搭建 + 批量 ORB。
+- `viz_scheme_compare.py` — 三面板对比视频（复用 `visualization/visualize_traj_video.py` 的投影）。
+- `deviation_vs_baseline.py` / `aggregate_schemes.py` — 完整度(输出帧/输入帧，丢帧=失败) + 偏差分析。
+- `orb_vs_vive.py` — ORB vs Vive 动捕真值 Sim3 对齐（Vive 准的时候用）。
+
+## 注意
+- `T_CAM_EE`（相机→夹爪指尖变换，在 `visualization/visualize_traj_video.py`）是按本装置实测重标定的（指尖 +0.145m 前/−0.030m 下、pitch −30°）。换装置请核验绿点是否落夹爪中心。
+- 脚本里的数据路径是示例（默认 `/home/ss/data/1000_onesb_labpicking`），用 `MASK_DATA` 环境变量或改 `BASE` 适配你的机器。
+- Vive 动捕在遮挡时会出错，不能盲信当真值；用前需识别并剔除被遮挡 episode。

--- a/schemes_compare/aggregate_schemes.py
+++ b/schemes_compare/aggregate_schemes.py
@@ -3,12 +3,18 @@
 每方案 失败集数(丢帧)/完整度 + maskhalf丢而maskgripper全 + 质量(两边跟全的偏差)。
 用法: python3 aggregate_schemes.py
 """
-import csv, glob
+import argparse, csv, glob, os
 from pathlib import Path
 import numpy as np
 
-base = Path("/home/ss/data/1000_onesb_labpicking")
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("data_root", nargs="?", type=Path,
+                    default=Path(os.environ.get("MASK_DATA", "/home/ss/data/1000_onesb_labpicking")))
+args = parser.parse_args()
+base = args.data_root.resolve()
 csvs = sorted(glob.glob(str(base / "*-schemes/_compare/deviation.csv")))
+if not csvs:
+    raise SystemExit(f"no deviation.csv files found under {base}")
 f = lambda x: float(x) if x not in (None, "NA", "") else None
 
 print(f"sessions: {len(csvs)}\n")
@@ -22,16 +28,18 @@ for c in csvs:
     sdev = []
     for r in rows:
         nin = f(r["nin"]); mh = f(r["maskhalf_n"]); mg = f(r["maskgripper_n"])
-        if nin and mh and mh < nin: mh_fail += 1
-        if nin and mg and mg < nin: mg_fail += 1
-        if nin and mh < nin and mg >= nin: saved += 1
-        if nin and mh == nin and mg == nin:  # 两边都跟全 → 质量可比
+        if nin is not None and mh is not None and mh < nin: mh_fail += 1
+        if nin is not None and mg is not None and mg < nin: mg_fail += 1
+        if (nin is not None and mh is not None and mg is not None
+                and mh < nin and mg >= nin): saved += 1
+        if nin is not None and mh == nin and mg == nin:  # 两边都跟全 → 质量可比
             d = f(r["rmse_mg_vs_mh_mm"])
-            if d: sdev.append(d)
+            if d is not None: sdev.append(d)
     dev_med = np.median(sdev) if sdev else float("nan")
     print(f"{sess:<16}{len(rows):>4}{mh_fail:>7}{mg_fail:>7}{saved:>9}{dev_med:>9.1f}mm")
     tot_eps += len(rows); tot_mh += mh_fail; tot_mg += mg_fail; tot_saved += saved; both_dev += sdev
 
-print(f"{'TOTAL':<16}{tot_eps:>4}{tot_mh:>7}{tot_mg:>7}{tot_saved:>9}{np.median(both_dev):>9.1f}mm")
+overall_med = np.median(both_dev) if both_dev else float("nan")
+print(f"{'TOTAL':<16}{tot_eps:>4}{tot_mh:>7}{tot_mg:>7}{tot_saved:>9}{overall_med:>9.1f}mm")
 print(f"\n总结: {tot_eps} 集 | maskhalf 失败 {tot_mh} | maskgripper 失败 {tot_mg} | maskgripper 救回(maskhalf丢它全) {tot_saved}")
-print(f"质量(两边都跟全, n={len(both_dev)}): maskgripper vs maskhalf 偏差中位 {np.median(both_dev):.1f}mm → 等价")
+print(f"质量(两边都跟全, n={len(both_dev)}): maskgripper vs maskhalf 偏差中位 {overall_med:.1f}mm → 等价")

--- a/schemes_compare/aggregate_schemes.py
+++ b/schemes_compare/aggregate_schemes.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""汇总所有 *-schemes 的偏差表 → 跨 session 总表：
-每方案 失败集数(丢帧)/完整度 + maskhalf丢而maskgripper全 + 质量(两边跟全的偏差)。
-用法: python3 aggregate_schemes.py
+"""Aggregate deviation tables from all *-schemes directories.
+Reports failures/completeness, maskgripper recoveries, and full-track deviation.
+Usage: aggregate_schemes.py [data_root]
 """
 import argparse, csv, glob, os
 from pathlib import Path
@@ -18,7 +18,7 @@ if not csvs:
 f = lambda x: float(x) if x not in (None, "NA", "") else None
 
 print(f"sessions: {len(csvs)}\n")
-print(f"{'session':<16}{'eps':>4}{'mh失败':>7}{'mg失败':>7}{'mh丢mg全':>9}{'mg-mh偏差':>10}")
+print(f"{'session':<16}{'eps':>4}{'mh fail':>9}{'mg fail':>9}{'mg saves':>10}{'mg-mh dev':>11}")
 tot_eps = tot_mh = tot_mg = tot_saved = 0
 both_dev = []
 for c in csvs:
@@ -32,7 +32,7 @@ for c in csvs:
         if nin is not None and mg is not None and mg < nin: mg_fail += 1
         if (nin is not None and mh is not None and mg is not None
                 and mh < nin and mg >= nin): saved += 1
-        if nin is not None and mh == nin and mg == nin:  # 两边都跟全 → 质量可比
+        if nin is not None and mh == nin and mg == nin:  # Comparable quality when both track fully
             d = f(r["rmse_mg_vs_mh_mm"])
             if d is not None: sdev.append(d)
     dev_med = np.median(sdev) if sdev else float("nan")
@@ -41,5 +41,5 @@ for c in csvs:
 
 overall_med = np.median(both_dev) if both_dev else float("nan")
 print(f"{'TOTAL':<16}{tot_eps:>4}{tot_mh:>7}{tot_mg:>7}{tot_saved:>9}{overall_med:>9.1f}mm")
-print(f"\n总结: {tot_eps} 集 | maskhalf 失败 {tot_mh} | maskgripper 失败 {tot_mg} | maskgripper 救回(maskhalf丢它全) {tot_saved}")
-print(f"质量(两边都跟全, n={len(both_dev)}): maskgripper vs maskhalf 偏差中位 {overall_med:.1f}mm → 等价")
+print(f"\nSummary: {tot_eps} episodes | maskhalf failures {tot_mh} | maskgripper failures {tot_mg} | maskgripper recoveries {tot_saved}")
+print(f"Quality (both tracked fully, n={len(both_dev)}): median maskgripper-vs-maskhalf deviation {overall_med:.1f}mm")

--- a/schemes_compare/aggregate_schemes.py
+++ b/schemes_compare/aggregate_schemes.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""汇总所有 *-schemes 的偏差表 → 跨 session 总表：
+每方案 失败集数(丢帧)/完整度 + maskhalf丢而maskgripper全 + 质量(两边跟全的偏差)。
+用法: python3 aggregate_schemes.py
+"""
+import csv, glob
+from pathlib import Path
+import numpy as np
+
+base = Path("/home/ss/data/1000_onesb_labpicking")
+csvs = sorted(glob.glob(str(base / "*-schemes/_compare/deviation.csv")))
+f = lambda x: float(x) if x not in (None, "NA", "") else None
+
+print(f"sessions: {len(csvs)}\n")
+print(f"{'session':<16}{'eps':>4}{'mh失败':>7}{'mg失败':>7}{'mh丢mg全':>9}{'mg-mh偏差':>10}")
+tot_eps = tot_mh = tot_mg = tot_saved = 0
+both_dev = []
+for c in csvs:
+    sess = Path(c).parents[1].name.replace("-schemes", "")
+    rows = list(csv.DictReader(open(c)))
+    mh_fail = mg_fail = saved = 0
+    sdev = []
+    for r in rows:
+        nin = f(r["nin"]); mh = f(r["maskhalf_n"]); mg = f(r["maskgripper_n"])
+        if nin and mh and mh < nin: mh_fail += 1
+        if nin and mg and mg < nin: mg_fail += 1
+        if nin and mh < nin and mg >= nin: saved += 1
+        if nin and mh == nin and mg == nin:  # 两边都跟全 → 质量可比
+            d = f(r["rmse_mg_vs_mh_mm"])
+            if d: sdev.append(d)
+    dev_med = np.median(sdev) if sdev else float("nan")
+    print(f"{sess:<16}{len(rows):>4}{mh_fail:>7}{mg_fail:>7}{saved:>9}{dev_med:>9.1f}mm")
+    tot_eps += len(rows); tot_mh += mh_fail; tot_mg += mg_fail; tot_saved += saved; both_dev += sdev
+
+print(f"{'TOTAL':<16}{tot_eps:>4}{tot_mh:>7}{tot_mg:>7}{tot_saved:>9}{np.median(both_dev):>9.1f}mm")
+print(f"\n总结: {tot_eps} 集 | maskhalf 失败 {tot_mh} | maskgripper 失败 {tot_mg} | maskgripper 救回(maskhalf丢它全) {tot_saved}")
+print(f"质量(两边都跟全, n={len(both_dev)}): maskgripper vs maskhalf 偏差中位 {np.median(both_dev):.1f}mm → 等价")

--- a/schemes_compare/build_session_schemes.sh
+++ b/schemes_compare/build_session_schemes.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# 把一个 session 全量做成 schemes 结构：raw / maskhalf / maskgripper 各跑 ORB。
-# 中间产物 -png / -png-mask292 在并入 schemes 后删除（保持整洁）。
-# 用法: bash build_session_schemes.sh <session-basename>   例: 20260709_144719
+# Build a full schemes tree for one session and run ORB for every scheme.
+# Intermediate -png and -png-mask292 directories are removed after copying.
+# Usage: build_session_schemes.sh <session-basename>  Example: 20260709_144719
 set -e
 B="$1"
 BASE="${MASK_DATA:-/home/ss/data/1000_onesb_labpicking}"
@@ -18,10 +18,10 @@ python3 "$VIZ/mask_session.py" "$PNG" 292
 echo "### 3) schemes init (raw + maskhalf)"
 python3 "$VIZ/schemes_init.py" "$PNG" "$MASK" "$SCH"
 
-echo "### 4) 删冗余 -png / -png-mask292 (内容已并入 schemes)"
+echo "### 4) remove copied -png / -png-mask292 intermediates"
 rm -rf "$PNG" "$MASK"
 
-echo "### 5) maskgripper 梯形掩膜"
+echo "### 5) apply maskgripper trapezoid mask"
 python3 "$VIZ/mask_gripper_trapezoid.py" "$SCH"
 
 echo "### 6) ORB: raw / maskhalf / maskgripper"
@@ -29,4 +29,4 @@ for sch in raw maskhalf maskgripper; do
   python3 "$VIZ/run_orb_scheme.py" "$SCH" "$sch"
 done
 
-echo "=== $B schemes 全部完成 → $SCH ==="
+echo "=== $B schemes complete -> $SCH ==="

--- a/schemes_compare/build_session_schemes.sh
+++ b/schemes_compare/build_session_schemes.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# 把一个 session 全量做成 schemes 结构：raw / maskhalf / maskgripper 各跑 ORB。
+# 中间产物 -png / -png-mask292 在并入 schemes 后删除（保持整洁）。
+# 用法: bash build_session_schemes.sh <session-basename>   例: 20260709_144719
+set -e
+B="$1"
+BASE="${MASK_DATA:-/home/ss/data/1000_onesb_labpicking}"
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+VIZ="$(cd "$(dirname "$0")" && pwd)"
+MP4="$BASE/$B-mp4"; PNG="$BASE/$B-png"; MASK="$BASE/$B-png-mask292"; SCH="$BASE/$B-schemes"
+
+echo "### 1) decode $B"
+conda run -n lerobot --no-capture-output python "$REPO/decode_videos.py" "$MP4" --recursive
+
+echo "### 2) mask half (cutoff=292)"
+python3 "$VIZ/mask_session.py" "$PNG" 292
+
+echo "### 3) schemes init (raw + maskhalf)"
+python3 "$VIZ/schemes_init.py" "$PNG" "$MASK" "$SCH"
+
+echo "### 4) 删冗余 -png / -png-mask292 (内容已并入 schemes)"
+rm -rf "$PNG" "$MASK"
+
+echo "### 5) maskgripper 梯形掩膜"
+python3 "$VIZ/mask_gripper_trapezoid.py" "$SCH"
+
+echo "### 6) ORB: raw / maskhalf / maskgripper"
+for sch in raw maskhalf maskgripper; do
+  python3 "$VIZ/run_orb_scheme.py" "$SCH" "$sch"
+done
+
+echo "=== $B schemes 全部完成 → $SCH ==="

--- a/schemes_compare/deviation_vs_baseline.py
+++ b/schemes_compare/deviation_vs_baseline.py
@@ -18,7 +18,13 @@ def loadt(ep, sch):
     t = ep / sch / "CameraTrajectoryTransformed.txt"
     if not t.exists():
         t = ep / sch / "CameraTrajectory.txt"
-    return ovv.load_kitti_positions(t) if t.exists() else None
+    if not t.exists():
+        return None
+    try:
+        points = ovv.load_kitti_positions(t)
+    except (OSError, ValueError):
+        return None
+    return points if len(points) else None
 
 
 def ninput(ep):
@@ -32,7 +38,7 @@ def ninput(ep):
 
 
 def dev(A, B):
-    if A is None or B is None:
+    if A is None or B is None or len(A) == 0 or len(B) == 0:
         return None
     if len(A) != len(B):
         L = min(len(A), len(B))
@@ -49,9 +55,8 @@ rows = []
 for ep in eps:
     ni = ninput(ep)
     base = loadt(ep, "maskhalf"); mg = loadt(ep, "maskgripper"); raw = loadt(ep, "raw")
-    if base is None:
-        continue
-    rows.append(dict(ep=ep.name, nin=ni, mh_n=len(base), mg_n=len(mg) if mg is not None else 0,
+    rows.append(dict(ep=ep.name, nin=ni, mh_n=len(base) if base is not None else 0,
+                     mg_n=len(mg) if mg is not None else 0,
                      raw_n=len(raw) if raw is not None else 0, d_mg=dev(mg, base), d_raw=dev(raw, base),
                      mh_bbox=bbox(base), mg_bbox=bbox(mg)))
 
@@ -63,21 +68,28 @@ with open(csvp, "w", newline="") as f:
                 "rmse_mg_vs_mh_mm", "rmse_raw_vs_mh_mm", "mh_bbox_cm", "mg_bbox_cm"])
     for r in rows:
         w.writerow([r["ep"], r["nin"], r["mh_n"], r["mg_n"], r["raw_n"],
-                    f"{r['d_mg']*1000:.1f}" if r["d_mg"] else "NA",
-                    f"{r['d_raw']*1000:.1f}" if r["d_raw"] else "NA",
+                    f"{r['d_mg']*1000:.1f}" if r["d_mg"] is not None else "NA",
+                    f"{r['d_raw']*1000:.1f}" if r["d_raw"] is not None else "NA",
                     f"{r['mh_bbox']*100:.1f}", f"{r['mg_bbox']*100:.1f}"])
 
 comp = lambda r, k: (100 * r[k] / r["nin"]) if r["nin"] else 0
 mh_c = np.array([comp(r, "mh_n") for r in rows])
 mg_c = np.array([comp(r, "mg_n") for r in rows])
 print(f"{schemes.name}: n={len(rows)}  (thr={thr}mm)")
-print(f"  跟踪完整度: maskhalf mean={mh_c.mean():.0f}% (丢帧={int((mh_c < 100).sum())}) | "
-      f"maskgripper mean={mg_c.mean():.0f}% (丢帧={int((mg_c < 100).sum())})")
+if rows:
+    print(f"  跟踪完整度: maskhalf mean={mh_c.mean():.0f}% (丢帧={int((mh_c < 100).sum())}) | "
+          f"maskgripper mean={mg_c.mean():.0f}% (丢帧={int((mg_c < 100).sum())})")
+else:
+    print("  跟踪完整度: no episodes")
 lost = [r for r in rows if r["nin"] and r["mh_n"] < r["nin"] and r["mg_n"] >= r["nin"]]
 print(f"  ★ maskhalf丢帧 而 maskgripper跟全 的 episode: {len(lost)} 个")
 for r in lost:
     print(f"      {r['ep']}: maskhalf {r['mh_n']}/{r['nin']}  maskgripper {r['mg_n']}/{r['nin']}")
-mg = np.array([r["d_mg"] for r in rows if r["d_mg"]])
-ra = np.array([r["d_raw"] for r in rows if r["d_raw"]])
-print(f"  偏差: maskgripper vs maskhalf med={np.median(mg)*1000:.1f}mm | raw vs maskhalf med={np.median(ra)*1000:.1f}mm")
+mg = np.array([r["d_mg"] for r in rows if r["d_mg"] is not None])
+ra = np.array([r["d_raw"] for r in rows if r["d_raw"] is not None])
+mg_med = np.median(mg) * 1000 if len(mg) else float("nan")
+ra_med = np.median(ra) * 1000 if len(ra) else float("nan")
+over_thr = int((mg * 1000 > thr).sum()) if len(mg) else 0
+print(f"  偏差: maskgripper vs maskhalf med={mg_med:.1f}mm (>{thr:g}mm: {over_thr}) | "
+      f"raw vs maskhalf med={ra_med:.1f}mm")
 print(f"CSV: {csvp}")

--- a/schemes_compare/deviation_vs_baseline.py
+++ b/schemes_compare/deviation_vs_baseline.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""以 maskhalf 为基准，对比 maskgripper/raw 的：① 轨迹偏差(刚体RMSE) ② 跟踪完整度(输出帧/输入帧)。
-找 maskhalf 丢帧而 maskgripper 跟全 的 episode(说明遮夹爪更稳)。无需 Vive。
-用法: python deviation_vs_baseline.py <schemes_dir> [thr_mm=15]
+"""Compare maskgripper/raw against maskhalf using rigid RMSE and tracking completeness.
+Reports episodes where maskhalf loses frames but maskgripper tracks the full sequence.
+Usage: deviation_vs_baseline.py <schemes_dir> [threshold_mm=15]
 """
 import sys, csv
 from pathlib import Path
@@ -77,12 +77,12 @@ mh_c = np.array([comp(r, "mh_n") for r in rows])
 mg_c = np.array([comp(r, "mg_n") for r in rows])
 print(f"{schemes.name}: n={len(rows)}  (thr={thr}mm)")
 if rows:
-    print(f"  跟踪完整度: maskhalf mean={mh_c.mean():.0f}% (丢帧={int((mh_c < 100).sum())}) | "
-          f"maskgripper mean={mg_c.mean():.0f}% (丢帧={int((mg_c < 100).sum())})")
+    print(f"  completeness: maskhalf mean={mh_c.mean():.0f}% (losses={int((mh_c < 100).sum())}) | "
+          f"maskgripper mean={mg_c.mean():.0f}% (losses={int((mg_c < 100).sum())})")
 else:
-    print("  跟踪完整度: no episodes")
+    print("  completeness: no episodes")
 lost = [r for r in rows if r["nin"] and r["mh_n"] < r["nin"] and r["mg_n"] >= r["nin"]]
-print(f"  ★ maskhalf丢帧 而 maskgripper跟全 的 episode: {len(lost)} 个")
+print(f"  maskhalf lost frames while maskgripper tracked fully: {len(lost)} episode(s)")
 for r in lost:
     print(f"      {r['ep']}: maskhalf {r['mh_n']}/{r['nin']}  maskgripper {r['mg_n']}/{r['nin']}")
 mg = np.array([r["d_mg"] for r in rows if r["d_mg"] is not None])
@@ -90,6 +90,6 @@ ra = np.array([r["d_raw"] for r in rows if r["d_raw"] is not None])
 mg_med = np.median(mg) * 1000 if len(mg) else float("nan")
 ra_med = np.median(ra) * 1000 if len(ra) else float("nan")
 over_thr = int((mg * 1000 > thr).sum()) if len(mg) else 0
-print(f"  偏差: maskgripper vs maskhalf med={mg_med:.1f}mm (>{thr:g}mm: {over_thr}) | "
+print(f"  deviation: maskgripper vs maskhalf median={mg_med:.1f}mm (>{thr:g}mm: {over_thr}) | "
       f"raw vs maskhalf med={ra_med:.1f}mm")
 print(f"CSV: {csvp}")

--- a/schemes_compare/deviation_vs_baseline.py
+++ b/schemes_compare/deviation_vs_baseline.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""以 maskhalf 为基准，对比 maskgripper/raw 的：① 轨迹偏差(刚体RMSE) ② 跟踪完整度(输出帧/输入帧)。
+找 maskhalf 丢帧而 maskgripper 跟全 的 episode(说明遮夹爪更稳)。无需 Vive。
+用法: python deviation_vs_baseline.py <schemes_dir> [thr_mm=15]
+"""
+import sys, csv
+from pathlib import Path
+import numpy as np
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import orb_vs_vive as ovv
+
+schemes = Path(sys.argv[1])
+thr = float(sys.argv[2]) if len(sys.argv) > 2 else 15.0
+eps = sorted(d for d in schemes.iterdir() if d.is_dir() and d.name.startswith("episode_"))
+
+
+def loadt(ep, sch):
+    t = ep / sch / "CameraTrajectoryTransformed.txt"
+    if not t.exists():
+        t = ep / sch / "CameraTrajectory.txt"
+    return ovv.load_kitti_positions(t) if t.exists() else None
+
+
+def ninput(ep):
+    t = ep / "times.txt"
+    if t.exists():
+        try:
+            return int(len(np.loadtxt(t).reshape(-1)))
+        except Exception:
+            pass
+    return None
+
+
+def dev(A, B):
+    if A is None or B is None:
+        return None
+    if len(A) != len(B):
+        L = min(len(A), len(B))
+        A, B = ovv.resample_to_length(A, L), ovv.resample_to_length(B, L)
+    s, R, t = ovv.umeyama(A, B, with_scale=False)
+    return float(np.sqrt(np.mean(np.sum(((R @ A.T).T + t - B) ** 2, axis=1))))
+
+
+def bbox(P):
+    return float(np.linalg.norm(P.max(0) - P.min(0))) if P is not None and len(P) else 0.0
+
+
+rows = []
+for ep in eps:
+    ni = ninput(ep)
+    base = loadt(ep, "maskhalf"); mg = loadt(ep, "maskgripper"); raw = loadt(ep, "raw")
+    if base is None:
+        continue
+    rows.append(dict(ep=ep.name, nin=ni, mh_n=len(base), mg_n=len(mg) if mg is not None else 0,
+                     raw_n=len(raw) if raw is not None else 0, d_mg=dev(mg, base), d_raw=dev(raw, base),
+                     mh_bbox=bbox(base), mg_bbox=bbox(mg)))
+
+outdir = schemes / "_compare"; outdir.mkdir(exist_ok=True)
+csvp = outdir / "deviation.csv"
+with open(csvp, "w", newline="") as f:
+    w = csv.writer(f)
+    w.writerow(["episode", "nin", "maskhalf_n", "maskgripper_n", "raw_n",
+                "rmse_mg_vs_mh_mm", "rmse_raw_vs_mh_mm", "mh_bbox_cm", "mg_bbox_cm"])
+    for r in rows:
+        w.writerow([r["ep"], r["nin"], r["mh_n"], r["mg_n"], r["raw_n"],
+                    f"{r['d_mg']*1000:.1f}" if r["d_mg"] else "NA",
+                    f"{r['d_raw']*1000:.1f}" if r["d_raw"] else "NA",
+                    f"{r['mh_bbox']*100:.1f}", f"{r['mg_bbox']*100:.1f}"])
+
+comp = lambda r, k: (100 * r[k] / r["nin"]) if r["nin"] else 0
+mh_c = np.array([comp(r, "mh_n") for r in rows])
+mg_c = np.array([comp(r, "mg_n") for r in rows])
+print(f"{schemes.name}: n={len(rows)}  (thr={thr}mm)")
+print(f"  跟踪完整度: maskhalf mean={mh_c.mean():.0f}% (丢帧={int((mh_c < 100).sum())}) | "
+      f"maskgripper mean={mg_c.mean():.0f}% (丢帧={int((mg_c < 100).sum())})")
+lost = [r for r in rows if r["nin"] and r["mh_n"] < r["nin"] and r["mg_n"] >= r["nin"]]
+print(f"  ★ maskhalf丢帧 而 maskgripper跟全 的 episode: {len(lost)} 个")
+for r in lost:
+    print(f"      {r['ep']}: maskhalf {r['mh_n']}/{r['nin']}  maskgripper {r['mg_n']}/{r['nin']}")
+mg = np.array([r["d_mg"] for r in rows if r["d_mg"]])
+ra = np.array([r["d_raw"] for r in rows if r["d_raw"]])
+print(f"  偏差: maskgripper vs maskhalf med={np.median(mg)*1000:.1f}mm | raw vs maskhalf med={np.median(ra)*1000:.1f}mm")
+print(f"CSV: {csvp}")

--- a/schemes_compare/mask_gripper_trapezoid.py
+++ b/schemes_compare/mask_gripper_trapezoid.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""方案3 掩膜：夹爪梯形(整段固定，左右红外各一套顶点) + 底部467行及以下全黑。
+读 <schemes>/episode_NNN/raw/{left_,right_} 原图 → 写 maskgripper/{left_,right_}。
+用法: python3 mask_gripper_trapezoid.py <schemes_dir>
+"""
+import sys, os
+from pathlib import Path
+import cv2
+import numpy as np
+
+# 顺序: 顶左 → 顶右 → 底右 → 底左 (凸梯形, 不自交)
+LEFT_POLY  = np.array([[(236, 292), (417, 292), (525, 467), (127, 467)]], dtype=np.int32)
+RIGHT_POLY = np.array([[(182, 292), (365, 292), (444, 467), ( 46, 467)]], dtype=np.int32)
+BOTTOM_ROW = 467  # 该行及以下全部涂黑
+
+
+def apply_mask(img, poly):
+    out = img.copy()
+    cv2.fillPoly(out, poly, 0)     # 梯形涂黑
+    out[BOTTOM_ROW:] = 0           # 底部条带全宽涂黑
+    return out
+
+
+schemes = Path(sys.argv[1])
+eps = sorted(d for d in schemes.iterdir() if d.is_dir() and d.name.startswith("episode_"))
+for ep in eps:
+    raw = ep / "raw"
+    mg = ep / "maskgripper"
+    mg.mkdir(exist_ok=True)
+    for s in ["times.txt", "orb_slam_realsense_d405.yaml"]:   # symlink 共享文件
+        link = mg / s
+        if not link.exists():
+            os.symlink(f"../{s}", link)
+    nl = nr = 0
+    for p in sorted(raw.glob("left_*.png")):
+        cv2.imwrite(str(mg / p.name), apply_mask(cv2.imread(str(p)), LEFT_POLY));  nl += 1
+    for p in sorted(raw.glob("right_*.png")):
+        cv2.imwrite(str(mg / p.name), apply_mask(cv2.imread(str(p)), RIGHT_POLY)); nr += 1
+    print(f"  {ep.name}: {nl}L {nr}R", flush=True)
+print(f"done → {schemes} ({len(eps)} episodes)")

--- a/schemes_compare/mask_gripper_trapezoid.py
+++ b/schemes_compare/mask_gripper_trapezoid.py
@@ -1,25 +1,25 @@
 #!/usr/bin/env python3
-"""方案3 掩膜：夹爪梯形(整段固定，左右红外各一套顶点) + 底部467行及以下全黑。
-读 <schemes>/episode_NNN/raw/{left_,right_} 原图 → 写 maskgripper/{left_,right_}。
-用法: python3 mask_gripper_trapezoid.py <schemes_dir>
+"""Scheme 3 mask: a fixed gripper trapezoid per stereo eye plus a black bottom strip.
+Accepts a schemes/session directory or one episode directory. Reads from raw/ when
+present, otherwise from the episode root, and writes to episode/maskgripper/.
 """
 import sys, os
 from pathlib import Path
 import cv2
 import numpy as np
 
-# 顺序: 顶左 → 顶右 → 底右 → 底左 (凸梯形, 不自交)
+# Vertex order: top-left -> top-right -> bottom-right -> bottom-left (convex)
 LEFT_POLY  = np.array([[(236, 292), (417, 292), (525, 467), (127, 467)]], dtype=np.int32)
 RIGHT_POLY = np.array([[(182, 292), (365, 292), (444, 467), ( 46, 467)]], dtype=np.int32)
-BOTTOM_ROW = 467  # 该行及以下全部涂黑
+BOTTOM_ROW = 467  # Black out this row and everything below it
 
 
 def apply_mask(img, poly):
     if img is None:
         raise ValueError("cannot mask an unreadable image")
     out = img.copy()
-    cv2.fillPoly(out, poly, 0)     # 梯形涂黑
-    out[BOTTOM_ROW:] = 0           # 底部条带全宽涂黑
+    cv2.fillPoly(out, poly, 0)     # Black out the gripper trapezoid
+    out[BOTTOM_ROW:] = 0           # Black out the full-width bottom strip
     return out
 
 
@@ -54,4 +54,4 @@ for ep in eps:
             raise RuntimeError(f"failed to write image: {output}")
     nl, nr = len(left), len(right)
     print(f"  {ep.name}: {nl}L {nr}R", flush=True)
-print(f"done → {input_path} ({len(eps)} episodes)")
+print(f"done -> {input_path} ({len(eps)} episodes)")

--- a/schemes_compare/mask_gripper_trapezoid.py
+++ b/schemes_compare/mask_gripper_trapezoid.py
@@ -15,26 +15,43 @@ BOTTOM_ROW = 467  # 该行及以下全部涂黑
 
 
 def apply_mask(img, poly):
+    if img is None:
+        raise ValueError("cannot mask an unreadable image")
     out = img.copy()
     cv2.fillPoly(out, poly, 0)     # 梯形涂黑
     out[BOTTOM_ROW:] = 0           # 底部条带全宽涂黑
     return out
 
 
-schemes = Path(sys.argv[1])
-eps = sorted(d for d in schemes.iterdir() if d.is_dir() and d.name.startswith("episode_"))
+input_path = Path(sys.argv[1]).resolve()
+if not input_path.is_dir():
+    raise SystemExit(f"directory not found: {input_path}")
+if input_path.name.startswith("episode_"):
+    eps = [input_path]
+else:
+    eps = sorted(d for d in input_path.iterdir() if d.is_dir() and d.name.startswith("episode_"))
+if not eps:
+    raise SystemExit(f"no episode_* directories found under: {input_path}")
 for ep in eps:
-    raw = ep / "raw"
+    raw = ep / "raw" if (ep / "raw").is_dir() else ep
     mg = ep / "maskgripper"
     mg.mkdir(exist_ok=True)
-    for s in ["times.txt", "orb_slam_realsense_d405.yaml"]:   # symlink 共享文件
-        link = mg / s
-        if not link.exists():
-            os.symlink(f"../{s}", link)
-    nl = nr = 0
-    for p in sorted(raw.glob("left_*.png")):
-        cv2.imwrite(str(mg / p.name), apply_mask(cv2.imread(str(p)), LEFT_POLY));  nl += 1
-    for p in sorted(raw.glob("right_*.png")):
-        cv2.imwrite(str(mg / p.name), apply_mask(cv2.imread(str(p)), RIGHT_POLY)); nr += 1
+    shared = [ep / "times.txt", *sorted(ep.glob("orb_slam_*.yaml"))]
+    for source in shared:
+        link = mg / source.name
+        if source.exists() and not link.exists():
+            os.symlink(f"../{source.name}", link)
+    left = sorted(raw.glob("left_*.png"))
+    right = sorted(raw.glob("right_*.png"))
+    if not left or not right:
+        raise RuntimeError(f"missing stereo PNG images in {raw}")
+    for path, poly in [(p, LEFT_POLY) for p in left] + [(p, RIGHT_POLY) for p in right]:
+        image = cv2.imread(str(path), cv2.IMREAD_UNCHANGED)
+        if image is None:
+            raise RuntimeError(f"failed to read image: {path}")
+        output = mg / path.name
+        if not cv2.imwrite(str(output), apply_mask(image, poly)):
+            raise RuntimeError(f"failed to write image: {output}")
+    nl, nr = len(left), len(right)
     print(f"  {ep.name}: {nl}L {nr}R", flush=True)
-print(f"done → {schemes} ({len(eps)} episodes)")
+print(f"done → {input_path} ({len(eps)} episodes)")

--- a/schemes_compare/mask_gripper_trapezoid.py
+++ b/schemes_compare/mask_gripper_trapezoid.py
@@ -1,57 +1,59 @@
 #!/usr/bin/env python3
-"""Scheme 3 mask: a fixed gripper trapezoid per stereo eye plus a black bottom strip.
-Accepts a schemes/session directory or one episode directory. Reads from raw/ when
-present, otherwise from the episode root, and writes to episode/maskgripper/.
-"""
-import sys, os
+"""Apply a config-driven gripper mask to a schemes tree, session, or episode."""
+
+import argparse
 from pathlib import Path
-import cv2
-import numpy as np
+import sys
 
-# Vertex order: top-left -> top-right -> bottom-right -> bottom-left (convex)
-LEFT_POLY  = np.array([[(236, 292), (417, 292), (525, 467), (127, 467)]], dtype=np.int32)
-RIGHT_POLY = np.array([[(182, 292), (365, 292), (444, 467), ( 46, 467)]], dtype=np.int32)
-BOTTOM_ROW = 467  # Black out this row and everything below it
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
 
+from apply_gripper_mask import load_mask_config, prepare_masked_episode
 
-def apply_mask(img, poly):
-    if img is None:
-        raise ValueError("cannot mask an unreadable image")
-    out = img.copy()
-    cv2.fillPoly(out, poly, 0)     # Black out the gripper trapezoid
-    out[BOTTOM_ROW:] = 0           # Black out the full-width bottom strip
-    return out
+DEFAULT_MASK_CONFIG = REPO_ROOT / "configs" / "gripper_mask_sroi_v2_d405.json"
 
 
-input_path = Path(sys.argv[1]).resolve()
-if not input_path.is_dir():
-    raise SystemExit(f"directory not found: {input_path}")
-if input_path.name.startswith("episode_"):
-    eps = [input_path]
-else:
-    eps = sorted(d for d in input_path.iterdir() if d.is_dir() and d.name.startswith("episode_"))
-if not eps:
-    raise SystemExit(f"no episode_* directories found under: {input_path}")
-for ep in eps:
-    raw = ep / "raw" if (ep / "raw").is_dir() else ep
-    mg = ep / "maskgripper"
-    mg.mkdir(exist_ok=True)
-    shared = [ep / "times.txt", *sorted(ep.glob("orb_slam_*.yaml"))]
-    for source in shared:
-        link = mg / source.name
-        if source.exists() and not link.exists():
-            os.symlink(f"../{source.name}", link)
-    left = sorted(raw.glob("left_*.png"))
-    right = sorted(raw.glob("right_*.png"))
-    if not left or not right:
-        raise RuntimeError(f"missing stereo PNG images in {raw}")
-    for path, poly in [(p, LEFT_POLY) for p in left] + [(p, RIGHT_POLY) for p in right]:
-        image = cv2.imread(str(path), cv2.IMREAD_UNCHANGED)
-        if image is None:
-            raise RuntimeError(f"failed to read image: {path}")
-        output = mg / path.name
-        if not cv2.imwrite(str(output), apply_mask(image, poly)):
-            raise RuntimeError(f"failed to write image: {output}")
-    nl, nr = len(left), len(right)
-    print(f"  {ep.name}: {nl}L {nr}R", flush=True)
-print(f"done -> {input_path} ({len(eps)} episodes)")
+def find_episodes(path: Path) -> list[Path]:
+    if path.name.startswith("episode_") and path.is_dir():
+        return [path]
+    return sorted(
+        child
+        for child in path.iterdir()
+        if child.is_dir() and child.name.startswith("episode_")
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("path", type=Path, help="Schemes/session directory or one episode")
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=DEFAULT_MASK_CONFIG,
+        help=f"Gripper mask JSON config (default: {DEFAULT_MASK_CONFIG})",
+    )
+    args = parser.parse_args()
+    input_path = args.path.resolve()
+    if not input_path.is_dir():
+        parser.error(f"directory not found: {input_path}")
+
+    episodes = find_episodes(input_path)
+    if not episodes:
+        parser.error(f"no episode_* directories found under: {input_path}")
+
+    try:
+        config = load_mask_config(args.config)
+        for episode in episodes:
+            source = episode / "raw" if (episode / "raw").is_dir() else episode
+            output = episode / "maskgripper"
+            left_count, right_count = prepare_masked_episode(source, output, config)
+            print(f"  {episode.name}: {left_count}L {right_count}R", flush=True)
+    except (OSError, ValueError) as error:
+        parser.error(str(error))
+
+    print(f"done -> {input_path} ({len(episodes)} episodes)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/schemes_compare/mask_session.py
+++ b/schemes_compare/mask_session.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""把整个 session 所有 episode 的图像底部涂黑。原图不动，写到 -mask<cutoff>/。
+
+用法: python mask_session.py <png_session> <cutoff_row>
+例:   python mask_session.py .../20260709_144418-png 292
+      (第 292 行及以下涂黑；对应去掉底部 38/97 ≈ 39%)
+"""
+import sys, shutil
+from pathlib import Path
+import cv2
+
+
+def main():
+    src = Path(sys.argv[1]).resolve()
+    cutoff = int(sys.argv[2])
+    dst = src.parent / f"{src.name}-mask{cutoff}"
+    eps = sorted(d for d in src.iterdir() if d.is_dir() and d.name.startswith("episode_"))
+    print(f"{src.name}: {len(eps)} episodes, cutoff={cutoff} (第{cutoff}行及以下涂黑) → {dst.name}")
+    for i, ep in enumerate(eps, 1):
+        d = dst / ep.name
+        d.mkdir(parents=True, exist_ok=True)
+        for name in ["orb_slam_realsense_d405.yaml", "times.txt", "timestamps.json",
+                     "camera_info_left.json", "camera_info_right.json", "camera_info_color.json"]:
+            s = ep / name
+            if s.exists():
+                shutil.copy2(s, d / name)
+        for pat in ["left_*.png", "right_*.png", "color_*.png"]:
+            for p in sorted(ep.glob(pat)):
+                img = cv2.imread(str(p), cv2.IMREAD_UNCHANGED)
+                if img is None:
+                    continue
+                img[cutoff:, ...] = 0
+                cv2.imwrite(str(d / p.name), img)
+        print(f"  [{i}/{len(eps)}] {ep.name}", flush=True)
+    print(f"done → {dst}")
+
+
+if __name__ == "__main__":
+    main()

--- a/schemes_compare/mask_session.py
+++ b/schemes_compare/mask_session.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""把整个 session 所有 episode 的图像底部涂黑。原图不动，写到 -mask<cutoff>/。
+"""Mask the bottom of every image in every episode of a session.
 
-用法: python mask_session.py <png_session> <cutoff_row>
-例:   python mask_session.py .../20260709_144418-png 292
-      (第 292 行及以下涂黑；对应去掉底部 38/97 ≈ 39%)
+The source images are unchanged; output is written to -mask<cutoff>/.
+Usage: python mask_session.py <png_session> <cutoff_row>
+Example: python mask_session.py .../20260709_144418-png 292
 """
 import sys, shutil
 from pathlib import Path
@@ -15,7 +15,7 @@ def main():
     cutoff = int(sys.argv[2])
     dst = src.parent / f"{src.name}-mask{cutoff}"
     eps = sorted(d for d in src.iterdir() if d.is_dir() and d.name.startswith("episode_"))
-    print(f"{src.name}: {len(eps)} episodes, cutoff={cutoff} (第{cutoff}行及以下涂黑) → {dst.name}")
+    print(f"{src.name}: {len(eps)} episodes, masking rows {cutoff} and below -> {dst.name}")
     for i, ep in enumerate(eps, 1):
         d = dst / ep.name
         d.mkdir(parents=True, exist_ok=True)
@@ -32,7 +32,7 @@ def main():
                 img[cutoff:, ...] = 0
                 cv2.imwrite(str(d / p.name), img)
         print(f"  [{i}/{len(eps)}] {ep.name}", flush=True)
-    print(f"done → {dst}")
+    print(f"done -> {dst}")
 
 
 if __name__ == "__main__":

--- a/schemes_compare/orb_vs_vive.py
+++ b/schemes_compare/orb_vs_vive.py
@@ -1,26 +1,26 @@
 #!/usr/bin/env python3
 """
-ORB-SLAM 轨迹 vs Vive 动捕真值：对齐 + 量尺度。
+Compare an ORB-SLAM trajectory with Vive motion capture: alignment and scale.
 
-每个 episode：
-  - CameraTrajectory.txt  (ORB-SLAM3 KITTI 输出, 在 -png 目录)   → 相机估计位姿
-  - vive_poses.jsonl      (Vive 动捕, ~240Hz, 在 -mp4 目录)       → 真值位姿
-  - times.txt             (相机帧 UNIX 时间戳, 在 -mp4 目录)
+Per episode inputs:
+  - CameraTrajectory.txt (ORB-SLAM3 KITTI output in the -png directory)
+  - vive_poses.jsonl (Vive motion capture at about 240 Hz in the -mp4 directory)
+  - times.txt (camera-frame UNIX timestamps in the -mp4 directory)
 
-做法：
-  1. 把 Vive 按时间插值到相机帧时刻 → 得到与相机帧一一对应的 Vive 真值位置。
-  2. ORB 帧数 M 与相机帧数 N 若不等(ORB 丢帧)，按"归一化进度"重采样两者到等长，
-     再做 Umeyama Sim3 对齐（只对位置）。s = 把 ORB 缩放到匹配 Vive 的因子。
-       s≈1 → 尺度一致；s>1 → ORB 偏小(基线偏小)；s<1 → ORB 偏大。
-  3. 另算一个不依赖对应的 bbox 对角线之比，交叉验证 s。
+Method:
+  1. Interpolate Vive positions at camera-frame timestamps.
+  2. If the ORB and camera frame counts differ, resample both by normalized progress
+     to equal length, then apply positional Umeyama Sim3 alignment. Scale s maps ORB
+     to Vive: s near 1 is consistent, s > 1 means ORB is small, and s < 1 means large.
+  3. Cross-check scale using a correspondence-independent bounding-box diagonal ratio.
 
-输出（写到 <png_session>_orbviz/）：
-  - 每个 episode 一个交互式 HTML：Vive(红) + ORB刚体对齐(蓝,不缩放) + ORB缩放对齐(绿)
-  - summary.csv：每行一个 episode 的 s / RMSE / 路径长 / bbox 比 / 帧数
+Outputs in <png_session>_orbviz/:
+  - Interactive HTML per episode: Vive, rigid-aligned ORB, and scale-aligned ORB
+  - summary.csv with scale, RMSE, path length, bounding-box ratio, and frame counts
 
-用法：
-  python orb_vs_vive.py <png_session目录>
-  (自动把路径里的 -png 换成 -mp4 找 Vive/times)
+Usage:
+  python orb_vs_vive.py <png_session>
+  (replaces -png with -mp4 automatically when locating Vive data and timestamps)
 """
 import sys, json, csv
 from pathlib import Path
@@ -28,7 +28,7 @@ import numpy as np
 
 
 def load_kitti_positions(p):
-    """KITTI 轨迹每行 12 个数 = 3x4 [R|t] 行优先；取第 4/8/12 列即平移。"""
+    """Load KITTI rows as row-major 3x4 [R|t] matrices and return translations."""
     a = np.atleast_2d(np.loadtxt(p))
     if a.shape[1] == 13:
         a = a[:, 1:]
@@ -54,7 +54,7 @@ def load_times(p):
 
 
 def umeyama(model, data, with_scale=True):
-    """对齐 model→data：返回 (s,R,t)，使 data ≈ (s·R·model + t)。"""
+    """Align model to data; return (s, R, t) such that data ~= s * R * model + t."""
     mu_m = model.mean(0); mu_d = data.mean(0)
     mz = model - mu_m; dz = data - mu_d
     n = len(model)
@@ -74,7 +74,7 @@ def umeyama(model, data, with_scale=True):
 
 
 def resample_to_length(P, L):
-    """把 (n,3) 轨迹按弧长(或索引)重采样到 L 个点，做点对点对应用。"""
+    """Resample an (n, 3) trajectory to L indexed points for pointwise alignment."""
     n = len(P)
     if n == L:
         return P
@@ -95,13 +95,13 @@ def process_episode(orb_txt, vive_jsonl, times_txt, out_html, name):
     T_vive, P_vive_full = load_vive(vive_jsonl)           # (K,),(K,3)
     T_cam = load_times(times_txt)                         # (N,)
 
-    # Vive 插值到相机帧时刻（越界 → nan）
+    # Interpolate Vive positions at camera timestamps; out-of-range samples become NaN.
     Pv_at_cam = np.column_stack([
         np.interp(T_cam, T_vive, P_vive_full[:, d],
                   left=np.nan, right=np.nan) for d in range(3)])  # (N,3)
     good = np.isfinite(Pv_at_cam).all(1)
     Pv = Pv_at_cam[good]
-    # ORB 与相机帧数对应：若相等直接配对；不等则按等长重采样（假设都覆盖整段）
+    # Pair equal-length inputs directly; otherwise resample, assuming both span the episode.
     if len(P_orb) == len(Pv):
         A, B = P_orb, Pv
     else:
@@ -109,37 +109,37 @@ def process_episode(orb_txt, vive_jsonl, times_txt, out_html, name):
         A = resample_to_length(P_orb, L)
         B = resample_to_length(Pv, L)
 
-    # 刚体对齐(不缩放) + Sim3(缩放)
+    # Rigid alignment without scale, then Sim3 alignment with scale.
     s1, R1, t1 = umeyama(A, B, with_scale=False)
     s, R, t = umeyama(A, B, with_scale=True)
-    A_rigid = (R1 @ A.T).T + t1                 # 蓝色：只对齐姿态，保留 ORB 原尺度
-    A_scaled = (s * (R @ A.T).T) + t            # 绿色：缩放后应与 Vive 重合
+    A_rigid = (R1 @ A.T).T + t1                 # Blue: aligned while preserving ORB scale
+    A_scaled = (s * (R @ A.T).T) + t            # Green: scaled alignment should match Vive
     rmse = float(np.sqrt(np.mean(np.sum((A_scaled - B) ** 2, axis=1))))
 
-    # 不依赖对应的尺度交叉验证
+    # Correspondence-independent scale cross-check.
     diag_orb = bbox_diag(P_orb); diag_vive = bbox_diag(Pv)
     bbox_ratio = diag_orb / diag_vive if diag_vive > 1e-9 else float("nan")
 
-    # ---- 交互式 HTML ----
+    # ---- Interactive HTML ----
     if out_html is not None:
         try:
             import plotly.graph_objects as go
             fig = go.Figure()
             fig.add_trace(go.Scatter3d(x=B[:, 0], y=B[:, 1], z=B[:, 2], mode="lines+markers",
                                        line=dict(width=4, color="red"), marker=dict(size=3),
-                                       name=f"Vive 真值 ({len(B)})"))
+                                       name=f"Vive reference ({len(B)})"))
             fig.add_trace(go.Scatter3d(x=A_rigid[:, 0], y=A_rigid[:, 1], z=A_rigid[:, 2], mode="lines",
-                                       line=dict(width=3, color="blue"), name="ORB 刚体对齐(不缩放)"))
+                                       line=dict(width=3, color="blue"), name="ORB rigid alignment (no scale)"))
             fig.add_trace(go.Scatter3d(x=A_scaled[:, 0], y=A_scaled[:, 1], z=A_scaled[:, 2], mode="lines",
-                                       line=dict(width=3, color="green"), name=f"ORB 缩放对齐 (s={s:.3f})"))
+                                       line=dict(width=3, color="green"), name=f"ORB scaled alignment (s={s:.3f})"))
             fig.update_layout(
                 title=(f"{name} | M_ORB={len(P_orb)} N_cam={len(T_cam)} | "
-                       f"Sim3 s={s:.3f}  RMSE={rmse*1000:.1f}mm | bbox比={bbox_ratio:.2f}"),
+                       f"Sim3 s={s:.3f}  RMSE={rmse*1000:.1f}mm | bbox ratio={bbox_ratio:.2f}"),
                 scene=dict(xaxis_title="X", yaxis_title="Y", zaxis_title="Z", aspectmode="data"),
                 width=980, height=760)
             fig.write_html(out_html)
         except Exception as e:
-            print(f"  (HTML 跳过 {name}: {e})")
+            print(f"  (skipping HTML for {name}: {e})")
 
     return dict(episode=name, M_orb=len(P_orb), N_cam=len(T_cam), n_pairs=len(A),
                 sim3_scale=s, rmse_mm=rmse * 1000, path_orb=path_len(P_orb),
@@ -152,18 +152,18 @@ def main():
     args = [a for a in sys.argv[1:] if a != "--no-html"]
     png_session = Path(args[0]).resolve()
     if len(args) > 1:
-        mp4_session = Path(args[1]).resolve()              # 显式指定 -mp4（掩膜衍生目录用）
+        mp4_session = Path(args[1]).resolve()  # Explicit -mp4 path for derived mask trees
     else:
         mp4_session = Path(str(png_session).replace("-png", "-mp4"))
     if not mp4_session.exists():
-        print(f"-mp4 目录不存在: {mp4_session}"); sys.exit(1)
+        print(f"-mp4 directory does not exist: {mp4_session}"); sys.exit(1)
 
     outdir = png_session.parent / (png_session.name.replace("-png", "-orbviz"))
     outdir.mkdir(exist_ok=True)
     no_html = "--no-html" in sys.argv
 
     eps = sorted(d for d in png_session.iterdir() if d.is_dir() and d.name.startswith("episode_"))
-    print(f"{png_session.name}: {len(eps)} episodes  →  {outdir}\n")
+    print(f"{png_session.name}: {len(eps)} episodes  ->  {outdir}\n")
 
     rows = []
     for ep in eps:
@@ -171,19 +171,19 @@ def main():
         vive = mp4_session / ep.name / "vive_poses.jsonl"
         times = mp4_session / ep.name / "times.txt"
         if not orb_txt.exists():
-            print(f"  {ep.name}: 无 CameraTrajectory.txt (ORB 没跑/失败)，跳过")
+            print(f"  {ep.name}: no CameraTrajectory.txt; skipping")
             continue
         if not vive.exists() or not times.exists():
-            print(f"  {ep.name}: 缺 Vive/times，跳过")
+            print(f"  {ep.name}: missing Vive data or timestamps; skipping")
             continue
         html = None if no_html else outdir / f"{ep.name}.html"
         try:
             r = process_episode(orb_txt, vive, times, html, ep.name)
             rows.append(r)
             print(f"  {ep.name}: s={r['sim3_scale']:.3f}  RMSE={r['rmse_mm']:.1f}mm  "
-                  f"bbox比={r['bbox_ratio']:.2f}  (M={r['M_orb']} N={r['N_cam']})")
+                  f"bbox ratio={r['bbox_ratio']:.2f}  (M={r['M_orb']} N={r['N_cam']})")
         except Exception as e:
-            print(f"  {ep.name}: 出错 {e}")
+            print(f"  {ep.name}: error: {e}")
 
     if rows:
         csvp = outdir / "summary.csv"
@@ -192,11 +192,11 @@ def main():
             w.writeheader(); w.writerows(rows)
         s = np.array([r["sim3_scale"] for r in rows])
         br = np.array([r["bbox_ratio"] for r in rows])
-        print("\n================ 汇总 ================")
+        print("\n================ Summary ================")
         print(f"episodes: {len(rows)}")
-        print(f"Sim3 尺度因子 s  : mean={s.mean():.3f}  median={np.median(s):.3f}  std={s.std():.3f}")
-        print(f"  (s>1 → ORB偏小/基线偏小;  s<1 → ORB偏大;  s≈1 → 一致)")
-        print(f"bbox 对角线比     : mean={br.mean():.3f}  median={np.median(br):.3f}")
+        print(f"Sim3 scale s: mean={s.mean():.3f}  median={np.median(s):.3f}  std={s.std():.3f}")
+        print("  (s > 1: ORB is small; s < 1: ORB is large; s ~= 1: consistent)")
+        print(f"bbox diagonal ratio: mean={br.mean():.3f}  median={np.median(br):.3f}")
         print(f"CSV: {csvp}")
 
 

--- a/schemes_compare/orb_vs_vive.py
+++ b/schemes_compare/orb_vs_vive.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""
+ORB-SLAM 轨迹 vs Vive 动捕真值：对齐 + 量尺度。
+
+每个 episode：
+  - CameraTrajectory.txt  (ORB-SLAM3 KITTI 输出, 在 -png 目录)   → 相机估计位姿
+  - vive_poses.jsonl      (Vive 动捕, ~240Hz, 在 -mp4 目录)       → 真值位姿
+  - times.txt             (相机帧 UNIX 时间戳, 在 -mp4 目录)
+
+做法：
+  1. 把 Vive 按时间插值到相机帧时刻 → 得到与相机帧一一对应的 Vive 真值位置。
+  2. ORB 帧数 M 与相机帧数 N 若不等(ORB 丢帧)，按"归一化进度"重采样两者到等长，
+     再做 Umeyama Sim3 对齐（只对位置）。s = 把 ORB 缩放到匹配 Vive 的因子。
+       s≈1 → 尺度一致；s>1 → ORB 偏小(基线偏小)；s<1 → ORB 偏大。
+  3. 另算一个不依赖对应的 bbox 对角线之比，交叉验证 s。
+
+输出（写到 <png_session>_orbviz/）：
+  - 每个 episode 一个交互式 HTML：Vive(红) + ORB刚体对齐(蓝,不缩放) + ORB缩放对齐(绿)
+  - summary.csv：每行一个 episode 的 s / RMSE / 路径长 / bbox 比 / 帧数
+
+用法：
+  python orb_vs_vive.py <png_session目录>
+  (自动把路径里的 -png 换成 -mp4 找 Vive/times)
+"""
+import sys, json, csv
+from pathlib import Path
+import numpy as np
+
+
+def load_kitti_positions(p):
+    """KITTI 轨迹每行 12 个数 = 3x4 [R|t] 行优先；取第 4/8/12 列即平移。"""
+    a = np.atleast_2d(np.loadtxt(p))
+    if a.shape[1] == 13:
+        a = a[:, 1:]
+    a = a.reshape(-1, 3, 4)
+    return a[:, :3, 3]              # (M,3)
+
+
+def load_vive(p):
+    times, pos = [], []
+    with open(p) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            d = json.loads(line)
+            times.append(d["time"])
+            pos.append(d["pos"])
+    return np.array(times), np.array(pos)   # (K,) (K,3)
+
+
+def load_times(p):
+    return np.loadtxt(p).reshape(-1)        # (N,)
+
+
+def umeyama(model, data, with_scale=True):
+    """对齐 model→data：返回 (s,R,t)，使 data ≈ (s·R·model + t)。"""
+    mu_m = model.mean(0); mu_d = data.mean(0)
+    mz = model - mu_m; dz = data - mu_d
+    n = len(model)
+    H = mz.T @ dz / n
+    U, S, Vt = np.linalg.svd(H)
+    D = np.eye(3)
+    if np.linalg.det(U @ Vt) < 0:
+        D[2, 2] = -1
+    R = Vt.T @ D @ U.T
+    if with_scale:
+        var_m = np.sum(np.var(model, axis=0))
+        s = np.trace(np.diag(S) @ D) / var_m if var_m > 1e-12 else 1.0
+    else:
+        s = 1.0
+    t = mu_d - s * R @ mu_m
+    return s, R, t
+
+
+def resample_to_length(P, L):
+    """把 (n,3) 轨迹按弧长(或索引)重采样到 L 个点，做点对点对应用。"""
+    n = len(P)
+    if n == L:
+        return P
+    idx = np.linspace(0, n - 1, L)
+    return np.column_stack([np.interp(idx, np.arange(n), P[:, d]) for d in range(3)])
+
+
+def bbox_diag(P):
+    return float(np.linalg.norm(P.max(0) - P.min(0)))
+
+
+def path_len(P):
+    return float(np.sum(np.linalg.norm(np.diff(P, axis=0), axis=1)))
+
+
+def process_episode(orb_txt, vive_jsonl, times_txt, out_html, name):
+    P_orb = load_kitti_positions(orb_txt)                 # (M,3)
+    T_vive, P_vive_full = load_vive(vive_jsonl)           # (K,),(K,3)
+    T_cam = load_times(times_txt)                         # (N,)
+
+    # Vive 插值到相机帧时刻（越界 → nan）
+    Pv_at_cam = np.column_stack([
+        np.interp(T_cam, T_vive, P_vive_full[:, d],
+                  left=np.nan, right=np.nan) for d in range(3)])  # (N,3)
+    good = np.isfinite(Pv_at_cam).all(1)
+    Pv = Pv_at_cam[good]
+    # ORB 与相机帧数对应：若相等直接配对；不等则按等长重采样（假设都覆盖整段）
+    if len(P_orb) == len(Pv):
+        A, B = P_orb, Pv
+    else:
+        L = min(len(P_orb), len(Pv))
+        A = resample_to_length(P_orb, L)
+        B = resample_to_length(Pv, L)
+
+    # 刚体对齐(不缩放) + Sim3(缩放)
+    s1, R1, t1 = umeyama(A, B, with_scale=False)
+    s, R, t = umeyama(A, B, with_scale=True)
+    A_rigid = (R1 @ A.T).T + t1                 # 蓝色：只对齐姿态，保留 ORB 原尺度
+    A_scaled = (s * (R @ A.T).T) + t            # 绿色：缩放后应与 Vive 重合
+    rmse = float(np.sqrt(np.mean(np.sum((A_scaled - B) ** 2, axis=1))))
+
+    # 不依赖对应的尺度交叉验证
+    diag_orb = bbox_diag(P_orb); diag_vive = bbox_diag(Pv)
+    bbox_ratio = diag_orb / diag_vive if diag_vive > 1e-9 else float("nan")
+
+    # ---- 交互式 HTML ----
+    if out_html is not None:
+        try:
+            import plotly.graph_objects as go
+            fig = go.Figure()
+            fig.add_trace(go.Scatter3d(x=B[:, 0], y=B[:, 1], z=B[:, 2], mode="lines+markers",
+                                       line=dict(width=4, color="red"), marker=dict(size=3),
+                                       name=f"Vive 真值 ({len(B)})"))
+            fig.add_trace(go.Scatter3d(x=A_rigid[:, 0], y=A_rigid[:, 1], z=A_rigid[:, 2], mode="lines",
+                                       line=dict(width=3, color="blue"), name="ORB 刚体对齐(不缩放)"))
+            fig.add_trace(go.Scatter3d(x=A_scaled[:, 0], y=A_scaled[:, 1], z=A_scaled[:, 2], mode="lines",
+                                       line=dict(width=3, color="green"), name=f"ORB 缩放对齐 (s={s:.3f})"))
+            fig.update_layout(
+                title=(f"{name} | M_ORB={len(P_orb)} N_cam={len(T_cam)} | "
+                       f"Sim3 s={s:.3f}  RMSE={rmse*1000:.1f}mm | bbox比={bbox_ratio:.2f}"),
+                scene=dict(xaxis_title="X", yaxis_title="Y", zaxis_title="Z", aspectmode="data"),
+                width=980, height=760)
+            fig.write_html(out_html)
+        except Exception as e:
+            print(f"  (HTML 跳过 {name}: {e})")
+
+    return dict(episode=name, M_orb=len(P_orb), N_cam=len(T_cam), n_pairs=len(A),
+                sim3_scale=s, rmse_mm=rmse * 1000, path_orb=path_len(P_orb),
+                path_vive=path_len(Pv), bbox_ratio=bbox_ratio)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print(__doc__); sys.exit(1)
+    args = [a for a in sys.argv[1:] if a != "--no-html"]
+    png_session = Path(args[0]).resolve()
+    if len(args) > 1:
+        mp4_session = Path(args[1]).resolve()              # 显式指定 -mp4（掩膜衍生目录用）
+    else:
+        mp4_session = Path(str(png_session).replace("-png", "-mp4"))
+    if not mp4_session.exists():
+        print(f"-mp4 目录不存在: {mp4_session}"); sys.exit(1)
+
+    outdir = png_session.parent / (png_session.name.replace("-png", "-orbviz"))
+    outdir.mkdir(exist_ok=True)
+    no_html = "--no-html" in sys.argv
+
+    eps = sorted(d for d in png_session.iterdir() if d.is_dir() and d.name.startswith("episode_"))
+    print(f"{png_session.name}: {len(eps)} episodes  →  {outdir}\n")
+
+    rows = []
+    for ep in eps:
+        orb_txt = ep / "CameraTrajectory.txt"
+        vive = mp4_session / ep.name / "vive_poses.jsonl"
+        times = mp4_session / ep.name / "times.txt"
+        if not orb_txt.exists():
+            print(f"  {ep.name}: 无 CameraTrajectory.txt (ORB 没跑/失败)，跳过")
+            continue
+        if not vive.exists() or not times.exists():
+            print(f"  {ep.name}: 缺 Vive/times，跳过")
+            continue
+        html = None if no_html else outdir / f"{ep.name}.html"
+        try:
+            r = process_episode(orb_txt, vive, times, html, ep.name)
+            rows.append(r)
+            print(f"  {ep.name}: s={r['sim3_scale']:.3f}  RMSE={r['rmse_mm']:.1f}mm  "
+                  f"bbox比={r['bbox_ratio']:.2f}  (M={r['M_orb']} N={r['N_cam']})")
+        except Exception as e:
+            print(f"  {ep.name}: 出错 {e}")
+
+    if rows:
+        csvp = outdir / "summary.csv"
+        with open(csvp, "w", newline="") as f:
+            w = csv.DictWriter(f, fieldnames=rows[0].keys())
+            w.writeheader(); w.writerows(rows)
+        s = np.array([r["sim3_scale"] for r in rows])
+        br = np.array([r["bbox_ratio"] for r in rows])
+        print("\n================ 汇总 ================")
+        print(f"episodes: {len(rows)}")
+        print(f"Sim3 尺度因子 s  : mean={s.mean():.3f}  median={np.median(s):.3f}  std={s.std():.3f}")
+        print(f"  (s>1 → ORB偏小/基线偏小;  s<1 → ORB偏大;  s≈1 → 一致)")
+        print(f"bbox 对角线比     : mean={br.mean():.3f}  median={np.median(br):.3f}")
+        print(f"CSV: {csvp}")
+
+
+if __name__ == "__main__":
+    main()

--- a/schemes_compare/run_orb_scheme.py
+++ b/schemes_compare/run_orb_scheme.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""对 schemes 结构里的某个方案子文件夹批量跑 ORB-SLAM3。
-读 <schemes>/episode_NNN/<scheme>/ 的 left_/right_(+symlink 的 yaml/times)，跑 stereo_kitti，
-轨迹存到该方案子文件夹。已有 CameraTrajectory.txt 则跳过。
-用法: python3 run_orb_scheme.py <schemes_dir> <scheme_name>   例: ... 144418-schemes maskgripper
+"""Run ORB-SLAM3 in batch for one scheme in a schemes tree.
+Reads stereo images plus linked YAML/timestamps from each episode scheme directory.
+Trajectories are stored in that directory; existing trajectories are skipped.
+Usage: run_orb_scheme.py <schemes_dir> <scheme_name> [--orbslam-dir PATH]
 """
-import argparse, os, sys, subprocess
+import argparse, os, subprocess
 from pathlib import Path
 
 parser = argparse.ArgumentParser(description=__doc__)
@@ -30,10 +30,10 @@ ok = skip = fail = 0
 for i, ep in enumerate(eps, 1):
     sd = ep / scheme
     if not sd.exists() or not (sd / "left_000000.png").exists():
-        print(f"[{i}/{len(eps)}] {ep.name}/{scheme}: 无图像，跳过", flush=True); skip += 1; continue
+        print(f"[{i}/{len(eps)}] {ep.name}/{scheme}: no images, skipping", flush=True); skip += 1; continue
     traj = sd / "CameraTrajectory.txt"
     if traj.exists():
-        print(f"[{i}/{len(eps)}] {ep.name}/{scheme}: 已有轨迹，跳过", flush=True); skip += 1; continue
+        print(f"[{i}/{len(eps)}] {ep.name}/{scheme}: trajectory exists, skipping", flush=True); skip += 1; continue
     cfg = sd / "orb_slam_realsense_d405.yaml"
     if not cfg.is_file():
         print(f"[{i}/{len(eps)}] {ep.name}/{scheme}: missing config {cfg}", flush=True)

--- a/schemes_compare/run_orb_scheme.py
+++ b/schemes_compare/run_orb_scheme.py
@@ -4,13 +4,26 @@
 轨迹存到该方案子文件夹。已有 CameraTrajectory.txt 则跳过。
 用法: python3 run_orb_scheme.py <schemes_dir> <scheme_name>   例: ... 144418-schemes maskgripper
 """
-import sys, subprocess
+import argparse, os, sys, subprocess
 from pathlib import Path
 
-ORB = Path.home() / "code" / "ORB_SLAM3"
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument("schemes_dir", type=Path)
+parser.add_argument("scheme_name")
+parser.add_argument("--orbslam-dir", type=Path,
+                    default=Path(os.environ.get("ORB_SLAM3_DIR", Path.home() / "code" / "ORB_SLAM3")))
+args = parser.parse_args()
+ORB = args.orbslam_dir.resolve()
 STEREO = ORB / "Examples" / "Stereo" / "stereo_kitti"
 VOCAB = ORB / "Vocabulary" / "ORBvoc.txt"
-schemes = Path(sys.argv[1]); scheme = sys.argv[2]
+if not STEREO.is_file():
+    parser.error(f"stereo_kitti not found: {STEREO}")
+if not os.access(STEREO, os.X_OK):
+    parser.error(f"stereo_kitti is not executable: {STEREO}")
+if not VOCAB.is_file():
+    parser.error(f"ORB vocabulary not found: {VOCAB}")
+schemes = args.schemes_dir.resolve()
+scheme = args.scheme_name
 
 eps = sorted(d for d in schemes.iterdir() if d.is_dir() and d.name.startswith("episode_"))
 ok = skip = fail = 0
@@ -22,9 +35,13 @@ for i, ep in enumerate(eps, 1):
     if traj.exists():
         print(f"[{i}/{len(eps)}] {ep.name}/{scheme}: 已有轨迹，跳过", flush=True); skip += 1; continue
     cfg = sd / "orb_slam_realsense_d405.yaml"
+    if not cfg.is_file():
+        print(f"[{i}/{len(eps)}] {ep.name}/{scheme}: missing config {cfg}", flush=True)
+        fail += 1
+        continue
     r = subprocess.run([str(STEREO), str(VOCAB), str(cfg), str(sd), "false"],
                        capture_output=True, text=True)
-    if traj.exists():
+    if r.returncode == 0 and traj.exists():
         ok += 1; print(f"[{i}/{len(eps)}] {ep.name}/{scheme}: done", flush=True)
     else:
         fail += 1; print(f"[{i}/{len(eps)}] {ep.name}/{scheme}: FAIL {r.stderr[-120:]}", flush=True)

--- a/schemes_compare/run_orb_scheme.py
+++ b/schemes_compare/run_orb_scheme.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""对 schemes 结构里的某个方案子文件夹批量跑 ORB-SLAM3。
+读 <schemes>/episode_NNN/<scheme>/ 的 left_/right_(+symlink 的 yaml/times)，跑 stereo_kitti，
+轨迹存到该方案子文件夹。已有 CameraTrajectory.txt 则跳过。
+用法: python3 run_orb_scheme.py <schemes_dir> <scheme_name>   例: ... 144418-schemes maskgripper
+"""
+import sys, subprocess
+from pathlib import Path
+
+ORB = Path.home() / "code" / "ORB_SLAM3"
+STEREO = ORB / "Examples" / "Stereo" / "stereo_kitti"
+VOCAB = ORB / "Vocabulary" / "ORBvoc.txt"
+schemes = Path(sys.argv[1]); scheme = sys.argv[2]
+
+eps = sorted(d for d in schemes.iterdir() if d.is_dir() and d.name.startswith("episode_"))
+ok = skip = fail = 0
+for i, ep in enumerate(eps, 1):
+    sd = ep / scheme
+    if not sd.exists() or not (sd / "left_000000.png").exists():
+        print(f"[{i}/{len(eps)}] {ep.name}/{scheme}: 无图像，跳过", flush=True); skip += 1; continue
+    traj = sd / "CameraTrajectory.txt"
+    if traj.exists():
+        print(f"[{i}/{len(eps)}] {ep.name}/{scheme}: 已有轨迹，跳过", flush=True); skip += 1; continue
+    cfg = sd / "orb_slam_realsense_d405.yaml"
+    r = subprocess.run([str(STEREO), str(VOCAB), str(cfg), str(sd), "false"],
+                       capture_output=True, text=True)
+    if traj.exists():
+        ok += 1; print(f"[{i}/{len(eps)}] {ep.name}/{scheme}: done", flush=True)
+    else:
+        fail += 1; print(f"[{i}/{len(eps)}] {ep.name}/{scheme}: FAIL {r.stderr[-120:]}", flush=True)
+print(f"=== {scheme}: ok={ok} skip={skip} fail={fail} / {len(eps)} ===")

--- a/schemes_compare/schemes_init.py
+++ b/schemes_compare/schemes_init.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""把已有 raw + maskhalf 结果整理进干净的 schemes 结构（每个 episode 下按方案分子文件夹）。
+内参/times/彩色在 episode 根共享；每个方案子文件夹放自己的 left_/right_ 图像 + 轨迹，
+并 symlink 共享的 times.txt + yaml 进来让子目录对 ORB 自洽。
+
+用法: python schemes_init.py <src_png> <src_mask292> <dst_schemes>
+"""
+import os, shutil, sys
+from pathlib import Path
+
+src_png = Path(sys.argv[1])
+src_mask = Path(sys.argv[2])
+dst = Path(sys.argv[3])
+META = ["camera_info_color.json", "camera_info_left.json", "camera_info_right.json",
+        "orb_slam_realsense_d405.yaml", "times.txt", "timestamps.json",
+        "vive_poses.jsonl", "vive_reference.json"]
+TRAJ = ["CameraTrajectory.txt", "CameraTrajectoryTransformed.txt"]
+
+
+def populate(sub_dir: Path, img_src: Path, traj_src: Path):
+    sub_dir.mkdir(parents=True, exist_ok=True)
+    for p in img_src.iterdir():
+        if p.name.startswith("left_") or p.name.startswith("right_"):
+            shutil.copy2(p, sub_dir / p.name)
+    for t in TRAJ:
+        s = traj_src / t
+        if s.exists() and not (sub_dir / t).exists():
+            shutil.copy2(s, sub_dir / t)
+    for shared in ["times.txt", "orb_slam_realsense_d405.yaml"]:   # symlink 共享文件进子目录
+        link = sub_dir / shared
+        if not link.exists():
+            os.symlink(f"../{shared}", link)
+
+
+eps = sorted(d.name for d in src_png.iterdir() if d.is_dir() and d.name.startswith("episode_"))
+for ep in eps:
+    root = dst / ep
+    root.mkdir(parents=True, exist_ok=True)
+    for m in META:
+        s = src_png / ep / m
+        if s.exists() and not (root / m).exists():
+            shutil.copy2(s, root / m)
+    for c in (src_png / ep).glob("color_*.png"):
+        shutil.copy2(c, root / c.name)
+    populate(root / "raw", src_png / ep, src_png / ep)
+    populate(root / "maskhalf", src_mask / ep, src_mask / ep)
+print(f"done → {dst} ({len(eps)} episodes)")

--- a/schemes_compare/schemes_init.py
+++ b/schemes_compare/schemes_init.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
-"""把已有 raw + maskhalf 结果整理进干净的 schemes 结构（每个 episode 下按方案分子文件夹）。
-内参/times/彩色在 episode 根共享；每个方案子文件夹放自己的 left_/right_ 图像 + 轨迹，
-并 symlink 共享的 times.txt + yaml 进来让子目录对 ORB 自洽。
+"""Arrange existing raw and maskhalf outputs into a clean schemes tree.
+Shared intrinsics, timestamps, and color frames stay at the episode root. Each scheme
+subdirectory contains its own stereo images and trajectories, with symlinks to shared
+times.txt and YAML files.
 
-用法: python schemes_init.py <src_png> <src_mask292> <dst_schemes>
+Usage: schemes_init.py <src_png> <src_mask292> <dst_schemes>
 """
 import os, shutil, sys
 from pathlib import Path
@@ -26,7 +27,7 @@ def populate(sub_dir: Path, img_src: Path, traj_src: Path):
         s = traj_src / t
         if s.exists() and not (sub_dir / t).exists():
             shutil.copy2(s, sub_dir / t)
-    for shared in ["times.txt", "orb_slam_realsense_d405.yaml"]:   # symlink 共享文件进子目录
+    for shared in ["times.txt", "orb_slam_realsense_d405.yaml"]:  # Link shared files
         link = sub_dir / shared
         if not link.exists():
             os.symlink(f"../{shared}", link)
@@ -44,4 +45,4 @@ for ep in eps:
         shutil.copy2(c, root / c.name)
     populate(root / "raw", src_png / ep, src_png / ep)
     populate(root / "maskhalf", src_mask / ep, src_mask / ep)
-print(f"done → {dst} ({len(eps)} episodes)")
+print(f"done -> {dst} ({len(eps)} episodes)")

--- a/schemes_compare/viz_scheme_compare.py
+++ b/schemes_compare/viz_scheme_compare.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""多方案对比视频：每 episode 横排 N 个 RGB 面板(每方案一个)，叠该方案的投影指尖路径
-(绿→红 + 绿当前点 + 蓝终点)，动画化，按 episode 序号拼成 ALL_compare.mp4。
-需先 transform 各方案轨迹(投影按 camera_link 系)。
-用法: python3 viz_scheme_compare.py <schemes_dir> [--schemes raw maskhalf maskgripper]
+"""Render an N-panel RGB comparison video for each episode, one panel per scheme.
+Each panel overlays the projected fingertip path from green to red, with a green current
+point and blue endpoint. Episode videos are concatenated into ALL_compare.mp4.
+Transform all trajectories first. Usage: viz_scheme_compare.py <schemes_dir> [--schemes ...]
 """
 import sys, argparse, subprocess
 from pathlib import Path
@@ -14,7 +14,7 @@ import matplotlib.pyplot as plt
 from matplotlib.collections import LineCollection
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "visualization"))
-import visualize_traj_video as vtv   # 复用 load_poses/load_K/project_future/TIP_KIN/_green_red_gradient
+import visualize_traj_video as vtv  # Reuse trajectory loading and projection helpers
 
 
 def render_episode(ep_dir, schemes, fps, codec, out_mp4):
@@ -104,10 +104,10 @@ def main():
     ap.add_argument("--codec", default="libopenh264")
     args = ap.parse_args()
     sd = Path(args.schemes_dir)
-    outdir = sd / "_compare"   # 放进 schemes 里，整洁
+    outdir = sd / "_compare"  # Keep comparison output inside the schemes tree
     outdir.mkdir(exist_ok=True)
     eps = sorted(d for d in sd.iterdir() if d.is_dir() and d.name.startswith("episode_"))
-    print(f"{sd.name}: {len(eps)} episodes × {args.schemes} → {outdir}", flush=True)
+    print(f"{sd.name}: {len(eps)} episodes x {args.schemes} -> {outdir}", flush=True)
     ok = 0
     for i, ep in enumerate(eps, 1):
         mp4 = outdir / f"{ep.name}.mp4"

--- a/schemes_compare/viz_scheme_compare.py
+++ b/schemes_compare/viz_scheme_compare.py
@@ -26,18 +26,21 @@ def render_episode(ep_dir, schemes, fps, codec, out_mp4):
         t = sd / "CameraTrajectoryTransformed.txt"
         if not t.exists():
             t = sd / "CameraTrajectory.txt"
-        p = vtv.load_poses(t)
-        if p is None or K is None:
-            return False
-        poses_per[sch] = p
-    n = min(len(color), *[len(poses_per[s]) for s in schemes])
+        poses_per[sch] = vtv.load_poses(t)
+    if K is None or not color or not any(p is not None for p in poses_per.values()):
+        return False
+    n = len(color)
     if n < 2:
         return False
     color = color[:n]
     for s in schemes:
-        poses_per[s] = poses_per[s][:n]
+        if poses_per[s] is not None:
+            poses_per[s] = poses_per[s][:n]
 
-    first = cv2.cvtColor(cv2.imread(str(color[0])), cv2.COLOR_BGR2RGB)
+    first_bgr = cv2.imread(str(color[0]))
+    if first_bgr is None:
+        raise RuntimeError(f"failed to read image: {color[0]}")
+    first = cv2.cvtColor(first_bgr, cv2.COLOR_BGR2RGB)
     H, W = first.shape[:2]
     nS = len(schemes)
     fig, axes = plt.subplots(1, nS, figsize=(4.4 * nS, 4.3), dpi=100)
@@ -46,7 +49,9 @@ def render_episode(ep_dir, schemes, fps, codec, out_mp4):
     im_objs, fut_lcs, start_dots, stop_dots = [], [], [], []
     for ax, sch in zip(axes, schemes):
         im_objs.append(ax.imshow(first)); ax.set_xticks([]); ax.set_yticks([])
-        ax.set_title(sch, fontsize=12, fontweight="bold")
+        tracked = len(poses_per[sch]) if poses_per[sch] is not None else 0
+        ax.set_title(f"{sch} ({tracked}/{len(color)} frames)",
+                     fontsize=12, fontweight="bold")
         lc = LineCollection([], linewidths=2.0, capstyle="round", zorder=4)
         ax.add_collection(lc); fut_lcs.append(lc)
         start_dots.append(ax.scatter([], [], c=["#00FF00"], s=45, zorder=6, edgecolors="black", linewidths=0.4))
@@ -62,16 +67,27 @@ def render_episode(ep_dir, schemes, fps, codec, out_mp4):
     proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
     try:
         for t in range(n):
-            img = cv2.cvtColor(cv2.imread(str(color[t])), cv2.COLOR_BGR2RGB)
+            frame = cv2.imread(str(color[t]))
+            if frame is None:
+                raise RuntimeError(f"failed to read image: {color[t]}")
+            img = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
             for i, sch in enumerate(schemes):
                 im_objs[i].set_data(img)
-                px, py = vtv.project_future(poses_per[sch], t, K)
-                pts = np.column_stack([px, py])
-                segs = np.stack([pts[:-1], pts[1:]], axis=1) if len(pts) >= 2 else np.empty((0, 2, 2))
-                fut_lcs[i].set_segments(segs); fut_lcs[i].set_colors(vtv._green_red_gradient(len(segs)))
-                start_dots[i].set_offsets([pts[0]] if len(pts) else [[np.nan, np.nan]])
-                spt = pts[-1] if len(pts) and np.isfinite(pts[-1]).all() else np.array([np.nan, np.nan])
-                stop_dots[i].set_offsets([spt])
+                if poses_per[sch] is not None and t < len(poses_per[sch]):
+                    px, py = vtv.project_future(poses_per[sch], t, K)
+                    pts = np.column_stack([px, py])
+                    segs = (np.stack([pts[:-1], pts[1:]], axis=1)
+                            if len(pts) >= 2 else np.empty((0, 2, 2)))
+                    fut_lcs[i].set_segments(segs)
+                    fut_lcs[i].set_colors(vtv._green_red_gradient(len(segs)))
+                    start_dots[i].set_offsets([pts[0]] if len(pts) else [[np.nan, np.nan]])
+                    spt = (pts[-1] if len(pts) and np.isfinite(pts[-1]).all()
+                           else np.array([np.nan, np.nan]))
+                    stop_dots[i].set_offsets([spt])
+                else:
+                    fut_lcs[i].set_segments([])
+                    start_dots[i].set_offsets([[np.nan, np.nan]])
+                    stop_dots[i].set_offsets([[np.nan, np.nan]])
             fig.canvas.draw()
             proc.stdin.write(np.asarray(fig.canvas.buffer_rgba())[..., :3].tobytes())
     except Exception:
@@ -85,7 +101,7 @@ def main():
     ap.add_argument("schemes_dir")
     ap.add_argument("--schemes", nargs="+", default=["raw", "maskhalf", "maskgripper"])
     ap.add_argument("--fps", type=int, default=20)
-    ap.add_argument("--codec", default="libx264")
+    ap.add_argument("--codec", default="libopenh264")
     args = ap.parse_args()
     sd = Path(args.schemes_dir)
     outdir = sd / "_compare"   # 放进 schemes 里，整洁

--- a/schemes_compare/viz_scheme_compare.py
+++ b/schemes_compare/viz_scheme_compare.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""多方案对比视频：每 episode 横排 N 个 RGB 面板(每方案一个)，叠该方案的投影指尖路径
+(绿→红 + 绿当前点 + 蓝终点)，动画化，按 episode 序号拼成 ALL_compare.mp4。
+需先 transform 各方案轨迹(投影按 camera_link 系)。
+用法: python3 viz_scheme_compare.py <schemes_dir> [--schemes raw maskhalf maskgripper]
+"""
+import sys, argparse, subprocess
+from pathlib import Path
+import numpy as np
+import cv2
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from matplotlib.collections import LineCollection
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "visualization"))
+import visualize_traj_video as vtv   # 复用 load_poses/load_K/project_future/TIP_KIN/_green_red_gradient
+
+
+def render_episode(ep_dir, schemes, fps, codec, out_mp4):
+    color = sorted([*ep_dir.glob("color_*.png"), *ep_dir.glob("color_*.jpg")])
+    K = vtv.load_K(ep_dir / "camera_info_color.json")
+    poses_per = {}
+    for sch in schemes:
+        sd = ep_dir / sch
+        t = sd / "CameraTrajectoryTransformed.txt"
+        if not t.exists():
+            t = sd / "CameraTrajectory.txt"
+        p = vtv.load_poses(t)
+        if p is None or K is None:
+            return False
+        poses_per[sch] = p
+    n = min(len(color), *[len(poses_per[s]) for s in schemes])
+    if n < 2:
+        return False
+    color = color[:n]
+    for s in schemes:
+        poses_per[s] = poses_per[s][:n]
+
+    first = cv2.cvtColor(cv2.imread(str(color[0])), cv2.COLOR_BGR2RGB)
+    H, W = first.shape[:2]
+    nS = len(schemes)
+    fig, axes = plt.subplots(1, nS, figsize=(4.4 * nS, 4.3), dpi=100)
+    if nS == 1:
+        axes = [axes]
+    im_objs, fut_lcs, start_dots, stop_dots = [], [], [], []
+    for ax, sch in zip(axes, schemes):
+        im_objs.append(ax.imshow(first)); ax.set_xticks([]); ax.set_yticks([])
+        ax.set_title(sch, fontsize=12, fontweight="bold")
+        lc = LineCollection([], linewidths=2.0, capstyle="round", zorder=4)
+        ax.add_collection(lc); fut_lcs.append(lc)
+        start_dots.append(ax.scatter([], [], c=["#00FF00"], s=45, zorder=6, edgecolors="black", linewidths=0.4))
+        stop_dots.append(ax.scatter([], [], c=["#0000FF"], s=45, zorder=6, edgecolors="black", linewidths=0.4))
+        ax.set_xlim(0, W); ax.set_ylim(H, 0)
+    fig.subplots_adjust(left=0.01, right=0.99, top=0.86, bottom=0.02, wspace=0.05)
+    fig.suptitle(f"{ep_dir.parent.name}/{ep_dir.name}", fontsize=11, y=0.97)
+
+    cw, ch = fig.canvas.get_width_height()
+    cmd = ["ffmpeg", "-y", "-loglevel", "error", "-f", "rawvideo", "-pix_fmt", "rgb24",
+           "-s", f"{cw}x{ch}", "-r", str(fps), "-i", "-",
+           "-c:v", codec, "-pix_fmt", "yuv420p", "-r", str(fps), str(out_mp4)]
+    proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+    try:
+        for t in range(n):
+            img = cv2.cvtColor(cv2.imread(str(color[t])), cv2.COLOR_BGR2RGB)
+            for i, sch in enumerate(schemes):
+                im_objs[i].set_data(img)
+                px, py = vtv.project_future(poses_per[sch], t, K)
+                pts = np.column_stack([px, py])
+                segs = np.stack([pts[:-1], pts[1:]], axis=1) if len(pts) >= 2 else np.empty((0, 2, 2))
+                fut_lcs[i].set_segments(segs); fut_lcs[i].set_colors(vtv._green_red_gradient(len(segs)))
+                start_dots[i].set_offsets([pts[0]] if len(pts) else [[np.nan, np.nan]])
+                spt = pts[-1] if len(pts) and np.isfinite(pts[-1]).all() else np.array([np.nan, np.nan])
+                stop_dots[i].set_offsets([spt])
+            fig.canvas.draw()
+            proc.stdin.write(np.asarray(fig.canvas.buffer_rgba())[..., :3].tobytes())
+    except Exception:
+        proc.kill(); plt.close(fig); raise
+    out, err = proc.communicate(); plt.close(fig)
+    return proc.returncode == 0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("schemes_dir")
+    ap.add_argument("--schemes", nargs="+", default=["raw", "maskhalf", "maskgripper"])
+    ap.add_argument("--fps", type=int, default=20)
+    ap.add_argument("--codec", default="libx264")
+    args = ap.parse_args()
+    sd = Path(args.schemes_dir)
+    outdir = sd / "_compare"   # 放进 schemes 里，整洁
+    outdir.mkdir(exist_ok=True)
+    eps = sorted(d for d in sd.iterdir() if d.is_dir() and d.name.startswith("episode_"))
+    print(f"{sd.name}: {len(eps)} episodes × {args.schemes} → {outdir}", flush=True)
+    ok = 0
+    for i, ep in enumerate(eps, 1):
+        mp4 = outdir / f"{ep.name}.mp4"
+        if mp4.exists() and mp4.stat().st_size > 10000:
+            print(f"[{i}/{len(eps)}] {ep.name} skip", flush=True); continue
+        if render_episode(ep, args.schemes, args.fps, args.codec, mp4):
+            ok += 1; print(f"[{i}/{len(eps)}] {ep.name} ok", flush=True)
+        else:
+            print(f"[{i}/{len(eps)}] {ep.name} skip(no data)", flush=True)
+    print("concatenating...", flush=True)
+    present = [e for e in eps if (outdir / f"{e.name}.mp4").exists()]
+    lf = outdir / "_concat.txt"
+    with open(lf, "w") as f:
+        for e in present:
+            f.write(f"file '{(outdir / f'{e.name}.mp4').resolve()}'\n")
+    final = outdir / "ALL_compare.mp4"
+    subprocess.run(["ffmpeg", "-y", "-f", "concat", "-safe", "0", "-i", str(lf),
+                    "-c", "copy", str(final)], capture_output=True)
+    print(f"DONE: {final} ({ok} episodes)", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/schemes_compare/viz_scheme_compare.py
+++ b/schemes_compare/viz_scheme_compare.py
@@ -17,7 +17,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "visualization")
 import visualize_traj_video as vtv  # Reuse trajectory loading and projection helpers
 
 
-def render_episode(ep_dir, schemes, fps, codec, out_mp4):
+def render_episode(ep_dir, schemes, fps, codec, out_mp4, tip_kin):
     color = sorted([*ep_dir.glob("color_*.png"), *ep_dir.glob("color_*.jpg")])
     K = vtv.load_K(ep_dir / "camera_info_color.json")
     poses_per = {}
@@ -74,7 +74,7 @@ def render_episode(ep_dir, schemes, fps, codec, out_mp4):
             for i, sch in enumerate(schemes):
                 im_objs[i].set_data(img)
                 if poses_per[sch] is not None and t < len(poses_per[sch]):
-                    px, py = vtv.project_future(poses_per[sch], t, K)
+                    px, py = vtv.project_future(poses_per[sch], t, K, tip_kin)
                     pts = np.column_stack([px, py])
                     segs = (np.stack([pts[:-1], pts[1:]], axis=1)
                             if len(pts) >= 2 else np.empty((0, 2, 2)))
@@ -102,7 +102,16 @@ def main():
     ap.add_argument("--schemes", nargs="+", default=["raw", "maskhalf", "maskgripper"])
     ap.add_argument("--fps", type=int, default=20)
     ap.add_argument("--codec", default="libopenh264")
+    ap.add_argument(
+        "--extrinsics-config",
+        type=Path,
+        default=vtv.DEFAULT_EXTRINSICS_CONFIG,
+    )
     args = ap.parse_args()
+    try:
+        tip_kin = vtv.load_tip_kin(args.extrinsics_config)
+    except ValueError as error:
+        ap.error(str(error))
     sd = Path(args.schemes_dir)
     outdir = sd / "_compare"  # Keep comparison output inside the schemes tree
     outdir.mkdir(exist_ok=True)
@@ -113,7 +122,7 @@ def main():
         mp4 = outdir / f"{ep.name}.mp4"
         if mp4.exists() and mp4.stat().st_size > 10000:
             print(f"[{i}/{len(eps)}] {ep.name} skip", flush=True); continue
-        if render_episode(ep, args.schemes, args.fps, args.codec, mp4):
+        if render_episode(ep, args.schemes, args.fps, args.codec, mp4, tip_kin):
             ok += 1; print(f"[{i}/{len(eps)}] {ep.name} ok", flush=True)
         else:
             print(f"[{i}/{len(eps)}] {ep.name} skip(no data)", flush=True)

--- a/visualization/visualize_traj_video.py
+++ b/visualization/visualize_traj_video.py
@@ -43,11 +43,15 @@ T_OPT_CAM = np.array([
     [0.9999999999999993, 2.6794896412773968e-08, 2.6794896468285145e-08, 0.0],
     [0.0, 0.0, 0.0, 1.0],
 ])
+# Recalibrated for this rig (2026-07-12, measured off the assembly drawing):
+# tip at +0.145 m forward, -0.030 m down in camera_link (X-fwd/Y-left/Z-up,
+# origin = optical center); gripper frame held horizontal while camera is tilted
+# 30deg down -> pitch -30deg about Y. (Point projection only uses the translation.)
 T_CAM_EE = np.array([
-    [1.601236272778861e-08, 0.5975900216637896, 0.8018018246473817, 0.12584794985962103],
-    [-0.9999999999999996, 2.679489641277399e-08, -4.963083675318166e-24, -0.00895],
-    [-2.1484196834999764e-08, -0.8018018246473815, 0.5975900216637897, 0.003582529990147798],
-    [0.0, 0.0, 0.0, 1.0],
+    [ 0.8660254, 0.0, -0.5,        0.145 ],
+    [ 0.0,       1.0,  0.0,        0.0   ],
+    [ 0.5,       0.0,  0.8660254, -0.030 ],
+    [ 0.0,       0.0,  0.0,        1.0   ],
 ])
 TIP_KIN = (T_OPT_CAM, T_CAM_EE)
 
@@ -129,7 +133,8 @@ def _out_mp4_path(ep_dir: Path, out_dir: Path | None) -> Path:
 
 
 def render_episode_video(ep_dir: Path, fps: int, codec: str, dpi: int = 100,
-                         out_dir: Path | None = None) -> bool:
+                         out_dir: Path | None = None,
+                         badge: str | None = None, badge_color: str = "#2e7d32") -> bool:
     """Render one side-by-side traj video. Returns True on success.
 
     Writes to <out_dir>/<session>_<episode>.mp4 when out_dir is set (all videos in one
@@ -165,6 +170,11 @@ def render_episode_video(ep_dir: Path, fps: int, codec: str, dpi: int = 100,
     ax_img = fig.add_subplot(1, 2, 1)
     ax3d = fig.add_subplot(1, 2, 2, projection="3d")
     fig.subplots_adjust(left=0.02, right=0.98, top=0.92, bottom=0.04, wspace=0.12)
+
+    if badge:  # optional status badge (colored block + text), top-left of the video
+        fig.text(0.005, 0.985, " " + badge + " ", color="white", fontsize=12,
+                 fontweight="bold", va="top", ha="left",
+                 bbox=dict(boxstyle="round,pad=0.35", fc=badge_color, ec="black", lw=1.0))
 
     first = cv.imread(str(images[0]))
     im_obj = ax_img.imshow(cv.cvtColor(first, cv.COLOR_BGR2RGB))
@@ -253,6 +263,8 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--max-episodes", type=int, default=0, help="Stop after N episodes (0 = no limit)")
     p.add_argument("--output", type=Path, default=None,
                    help="Write ALL videos into this folder as <session>_<episode>.mp4 (default: <episode>/traj_sidebyside.mp4)")
+    p.add_argument("--badge", default=None, help="Optional status badge text drawn top-left of the video")
+    p.add_argument("--badge-color", default="#2e7d32", help="Badge background color (default green)")
     args = p.parse_args(argv)
 
     if not args.path.exists():
@@ -277,7 +289,8 @@ def main(argv: list[str] | None = None) -> int:
         if args.max_episodes and ok >= args.max_episodes:
             break
         print(f"[{done+1}/{len(eps)}] {ep.parent.name}/{ep.name}")
-        if render_episode_video(ep, args.fps, args.codec, out_dir=args.output):
+        if render_episode_video(ep, args.fps, args.codec, out_dir=args.output,
+                                 badge=args.badge, badge_color=args.badge_color):
             ok += 1
         done += 1
     print(f"Done: {ok} video(s) rendered.")

--- a/visualization/visualize_traj_video.py
+++ b/visualization/visualize_traj_video.py
@@ -177,6 +177,10 @@ def render_episode_video(ep_dir: Path, fps: int, codec: str, dpi: int = 100,
                  bbox=dict(boxstyle="round,pad=0.35", fc=badge_color, ec="black", lw=1.0))
 
     first = cv.imread(str(images[0]))
+    if first is None:
+        print(f"  skip {ep_dir.name}: failed to read {images[0]}")
+        plt.close(fig)
+        return False
     im_obj = ax_img.imshow(cv.cvtColor(first, cv.COLOR_BGR2RGB))
     ax_img.set_xticks([]); ax_img.set_yticks([])
     title = ax_img.set_title(f"{ep_dir.parent.name}/{ep_dir.name}  f0/{n}", fontsize=10)
@@ -218,6 +222,8 @@ def render_episode_video(ep_dir: Path, fps: int, codec: str, dpi: int = 100,
     try:
         for t in range(n):
             img = cv.imread(str(images[t]))
+            if img is None:
+                raise RuntimeError(f"failed to read image: {images[t]}")
             im_obj.set_data(cv.cvtColor(img, cv.COLOR_BGR2RGB))
             title.set_text(f"{ep_dir.parent.name}/{ep_dir.name}  f{t}/{n-1}")
             # 3D panel: revealed path up to t + current head

--- a/visualization/visualize_traj_video.py
+++ b/visualization/visualize_traj_video.py
@@ -15,10 +15,14 @@ Usage (from repo root):
     # a whole session / parent tree
     python visualization/visualize_traj_video.py .../session-png --recursive
     python visualization/visualize_traj_video.py .../pngs --recursive
+    # use the calibration for a specific camera/gripper assembly
+    python visualization/visualize_traj_video.py .../session-png --recursive \
+        --extrinsics-config configs/camera_gripper_extrinsics_sroi_v2_d405.json
 Options: --fps 30 --codec libopenh264 --skip-existing --max-episodes N
 """
 
 import argparse
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -31,29 +35,49 @@ from matplotlib.collections import LineCollection
 from mpl_toolkits.mplot3d import Axes3D  # noqa: F401 (registers 3d projection)
 import numpy as np
 
-# Fixed camera<->gripper-tip transforms for the Piper rig, hardcoded from the
-# sroi-piper piper.urdf fixed-link chain (so we don't need placo/URDF at runtime).
-# Same values examples/umi_relative_ee/visualize_predictions.py computes live via
-# placo get_T_a_b("camera_optical_link","camera_link") and get_T_a_b("camera_link","ee_link").
-#   T_OPT_CAM : pose of camera_link in camera_optical_link frame (cam-link -> optical)
-#   T_CAM_EE  : pose of ee_link (gripper tip) in camera_link frame (tip offset)
-T_OPT_CAM = np.array([
-    [2.6794896412773997e-08, -0.9999999999999996, 5.183267242978961e-17, 0.0],
-    [2.6794896357262843e-08, 7.734776252012516e-16, -0.9999999999999998, 0.0],
-    [0.9999999999999993, 2.6794896412773968e-08, 2.6794896468285145e-08, 0.0],
-    [0.0, 0.0, 0.0, 1.0],
-])
-# Recalibrated for this rig (2026-07-12, measured off the assembly drawing):
-# tip at +0.145 m forward, -0.030 m down in camera_link (X-fwd/Y-left/Z-up,
-# origin = optical center); gripper frame held horizontal while camera is tilted
-# 30deg down -> pitch -30deg about Y. (Point projection only uses the translation.)
-T_CAM_EE = np.array([
-    [ 0.8660254, 0.0, -0.5,        0.145 ],
-    [ 0.0,       1.0,  0.0,        0.0   ],
-    [ 0.5,       0.0,  0.8660254, -0.030 ],
-    [ 0.0,       0.0,  0.0,        1.0   ],
-])
-TIP_KIN = (T_OPT_CAM, T_CAM_EE)
+# Projection extrinsics are loaded from a standalone rig config so different
+# camera/gripper assemblies can provide their own measured transforms.
+DEFAULT_EXTRINSICS_CONFIG = (
+    Path(__file__).resolve().parents[1]
+    / "configs"
+    / "camera_gripper_extrinsics_sroi_v2_d405.json"
+)
+
+
+def _load_rigid_transform(config: dict, key: str, config_path: Path) -> np.ndarray:
+    try:
+        transform = np.asarray(config[key], dtype=float)
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"{config_path}: {key} must be a numeric 4x4 matrix") from error
+    if transform.shape != (4, 4) or not np.isfinite(transform).all():
+        raise ValueError(f"{config_path}: {key} must be a finite 4x4 matrix")
+    if not np.allclose(transform[3], [0.0, 0.0, 0.0, 1.0], atol=1e-8):
+        raise ValueError(f"{config_path}: {key} must have homogeneous bottom row [0, 0, 0, 1]")
+    rotation = transform[:3, :3]
+    if not np.allclose(rotation.T @ rotation, np.eye(3), atol=1e-5):
+        raise ValueError(f"{config_path}: {key} rotation must be orthonormal")
+    if not np.isclose(np.linalg.det(rotation), 1.0, atol=1e-5):
+        raise ValueError(f"{config_path}: {key} rotation determinant must be +1")
+    return transform
+
+
+def load_tip_kin(config_path: Path | str) -> tuple[np.ndarray, np.ndarray]:
+    """Load optical<-camera and camera<-gripper-tip transforms from JSON."""
+    config_path = Path(config_path).resolve()
+    try:
+        with config_path.open() as config_file:
+            config = json.load(config_file)
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"failed to load extrinsics config {config_path}: {error}") from error
+    if not isinstance(config, dict) or config.get("schema_version") != 1:
+        raise ValueError(f"{config_path}: schema_version must be 1")
+    return (
+        _load_rigid_transform(config, "T_optical_camera", config_path),
+        _load_rigid_transform(config, "T_camera_gripper_tip", config_path),
+    )
+
+
+TIP_KIN = load_tip_kin(DEFAULT_EXTRINSICS_CONFIG)
 
 
 def load_poses(traj_path: Path) -> np.ndarray | None:
@@ -89,19 +113,24 @@ def load_K(cam_info_path: Path) -> np.ndarray | None:
     return K
 
 
-def project_future(poses: np.ndarray, t: int, K: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+def project_future(
+    poses: np.ndarray,
+    t: int,
+    K: np.ndarray,
+    tip_kin: tuple[np.ndarray, np.ndarray] = TIP_KIN,
+) -> tuple[np.ndarray, np.ndarray]:
     """Project the gripper-tip path from the CURRENT frame t through the end into
     frame t's image (includes the current tip so the trail starts "now").
 
     Mirrors visualize_predictions.py: poses are treated as camera_link poses; the
-    relative motion T_rel = inv(poses[t]) @ poses[k] is composed with the hardcoded
-    camera->tip offset (TIP_KIN), giving the gripper tip in the current optical frame:
+    relative motion T_rel = inv(poses[t]) @ poses[k] is composed with the configured
+    camera-to-tip transforms, giving the gripper tip in the current optical frame:
         p_tip = (T_opt_cam @ T_rel @ T_cam_ee)[:3, 3]
     then projected with the (optical) color intrinsics K. Returns (px, py) for k=t..end
     in pixel coords (NaN where behind the camera).
     """
     T_t_inv = np.linalg.inv(poses[t])
-    T_opt_cam, T_cam_ee = TIP_KIN
+    T_opt_cam, T_cam_ee = tip_kin
     pts = np.empty((len(poses) - t, 3))
     for i, k in enumerate(range(t, len(poses))):
         T_rel = T_t_inv @ poses[k]
@@ -134,7 +163,8 @@ def _out_mp4_path(ep_dir: Path, out_dir: Path | None) -> Path:
 
 def render_episode_video(ep_dir: Path, fps: int, codec: str, dpi: int = 100,
                          out_dir: Path | None = None,
-                         badge: str | None = None, badge_color: str = "#2e7d32") -> bool:
+                         badge: str | None = None, badge_color: str = "#2e7d32",
+                         tip_kin: tuple[np.ndarray, np.ndarray] = TIP_KIN) -> bool:
     """Render one side-by-side traj video. Returns True on success.
 
     Writes to <out_dir>/<session>_<episode>.mp4 when out_dir is set (all videos in one
@@ -233,7 +263,7 @@ def render_episode_video(ep_dir: Path, fps: int, codec: str, dpi: int = 100,
             # RGB panel: project gripper-tip path (current..end) into the frame,
             # drawn as a green->red gradient with green start (current tip) + blue stop.
             if K is not None:
-                px, py = project_future(poses, t, K)
+                px, py = project_future(poses, t, K, tip_kin)
                 pts = np.column_stack([px, py])
                 segs = np.stack([pts[:-1], pts[1:]], axis=1) if len(pts) >= 2 else np.empty((0, 2, 2))
                 fut_lc.set_segments(segs)
@@ -271,7 +301,18 @@ def main(argv: list[str] | None = None) -> int:
                    help="Write ALL videos into this folder as <session>_<episode>.mp4 (default: <episode>/traj_sidebyside.mp4)")
     p.add_argument("--badge", default=None, help="Optional status badge text drawn top-left of the video")
     p.add_argument("--badge-color", default="#2e7d32", help="Badge background color (default green)")
+    p.add_argument(
+        "--extrinsics-config",
+        type=Path,
+        default=DEFAULT_EXTRINSICS_CONFIG,
+        help=f"Camera-to-gripper-tip JSON config (default: {DEFAULT_EXTRINSICS_CONFIG})",
+    )
     args = p.parse_args(argv)
+
+    try:
+        tip_kin = load_tip_kin(args.extrinsics_config)
+    except ValueError as error:
+        p.error(str(error))
 
     if not args.path.exists():
         print(f"not found: {args.path}", file=sys.stderr); return 1
@@ -295,8 +336,15 @@ def main(argv: list[str] | None = None) -> int:
         if args.max_episodes and ok >= args.max_episodes:
             break
         print(f"[{done+1}/{len(eps)}] {ep.parent.name}/{ep.name}")
-        if render_episode_video(ep, args.fps, args.codec, out_dir=args.output,
-                                 badge=args.badge, badge_color=args.badge_color):
+        if render_episode_video(
+            ep,
+            args.fps,
+            args.codec,
+            out_dir=args.output,
+            badge=args.badge,
+            badge_color=args.badge_color,
+            tip_kin=tip_kin,
+        ):
             ok += 1
         done += 1
     print(f"Done: {ok} video(s) rendered.")


### PR DESCRIPTION
This pull request introduces an optional, rig-specific gripper masking feature to the ORB-SLAM3 batch processing scripts and documentation. Users can now provide a mask configuration to preprocess stereo frames before running ORB-SLAM3, improving robustness for different camera/gripper assemblies. The implementation includes a new Python utility for applying masks, updates to batch scripts to support the masking workflow, and expanded documentation on mask and projection configuration.

**New gripper masking feature:**

* Added a new script, `apply_gripper_mask.py`, which applies a configurable polygon mask (from a JSON file) to stereo frames, producing temporary masked input for ORB-SLAM3 without modifying the original data. The script includes input validation and ensures frame/metadata consistency.
* Updated `batches/orbslam_batch.sh` and `batches/orbslam_batch_d405.sh` to accept an optional `--mask-config PATH` argument. When provided, the scripts use the mask config to generate masked input via the new utility, run ORB-SLAM3 on the masked data, and copy results back to the original episode. [[1]](diffhunk://#diff-4f3251b24f8cd5a069cee1117b9c4bb2ca1a6675b6a2e41816c64db1de1a60e6R11) [[2]](diffhunk://#diff-4f3251b24f8cd5a069cee1117b9c4bb2ca1a6675b6a2e41816c64db1de1a60e6R22-R42) [[3]](diffhunk://#diff-4f3251b24f8cd5a069cee1117b9c4bb2ca1a6675b6a2e41816c64db1de1a60e6R55) [[4]](diffhunk://#diff-4f3251b24f8cd5a069cee1117b9c4bb2ca1a6675b6a2e41816c64db1de1a60e6R105-R127) [[5]](diffhunk://#diff-86b32c60d5fcec703622f6a7e1df91d1cfdb16938a2d55adc92e8081a9f4c6e2R12) [[6]](diffhunk://#diff-86b32c60d5fcec703622f6a7e1df91d1cfdb16938a2d55adc92e8081a9f4c6e2R22-R43) [[7]](diffhunk://#diff-86b32c60d5fcec703622f6a7e1df91d1cfdb16938a2d55adc92e8081a9f4c6e2R56) [[8]](diffhunk://#diff-86b32c60d5fcec703622f6a7e1df91d1cfdb16938a2d55adc92e8081a9f4c6e2R107-R129)

**Documentation updates:**

* Expanded `README.md` and `AGENTS.md` with instructions and explanations for the new masking workflow, including usage examples, configuration file schema, and links to further documentation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L53-R75) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R113-R126) [[3]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L30-R36) [[4]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R91-R93)
* Documented the use of rig-specific extrinsics for trajectory projection overlays, clarifying how to supply the appropriate configuration for different hardware setups. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R113-R126) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R91-R93)

**Other changes:**

* Cleaned up `.gitignore` and repo notes to clarify the handling of `AGENTS.md`.

These changes make the ORB-SLAM3 pipeline more flexible and robust for multi-rig environments, while ensuring that the original data remains untouched and all configuration is explicit and documented.